### PR TITLE
Resolved schema validation error during rake db:migrate

### DIFF
--- a/db/migrate/20110506063757_add_name_and_admin_to_users.rb
+++ b/db/migrate/20110506063757_add_name_and_admin_to_users.rb
@@ -1,6 +1,6 @@
 class AddNameAndAdminToUsers < ActiveRecord::Migration
   def self.up
-    add_column :users, :name, :string, :null => false, :after => :email
+    add_column :users, :name, :string, :default => "", :null => false, :after => :email
     add_column :users, :admin, :boolean, :default => false, :after => :name
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -78,7 +78,7 @@ ActiveRecord::Schema.define(:version => 20111027043132) do
     t.string   "last_sign_in_ip"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "name",                                                     :null => false
+    t.string   "name",                                  :default => "",    :null => false
     t.boolean  "admin",                                 :default => false
     t.boolean  "skill_teaching",                        :default => false
     t.boolean  "skill_taing",                           :default => false


### PR DESCRIPTION
The 20110506063757_add_name_and_admin_to_users.rb migration was causing an error during rake db:migrate reported by Jen Linder,

error:
SQLite3::SQLException: Cannot add a NOT NULL column with default value NULL: ALTER TABLE "users" ADD "name" varchar(255) NOT NULL 
