### PR TITLE
Fix double negative in User#skills.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,8 +27,8 @@ class User < ActiveRecord::Base
   has_many :events, :through => :registrations
 
   def skills
-    SKILLS.reject do |skill|
-      !send("skill_" + skill)
+    SKILLS.select do |skill|
+      send("skill_" + skill)
     end
   end
 end


### PR DESCRIPTION
Double negatives are hard to read and understand. Since there is
a Ruby method that does the exact same thing with more clarity,
we might as well use that.
