### PR TITLE
.rvmrc failing on cd into project  for RVM version 1.8.6

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,1 @@
-rvm 1.9.2-p290@bridgetroll
+rvm use 1.9.2-p290@bridgetroll --create


### PR DESCRIPTION
The --create option was giving me rvm failure for version 1.8.6. I tried updating to the latest version of RVM to see if it would fix the problem, but I was already there. Please check out your own version/errors. Maybe this is just a weird anomaly with my system.

My fix is not creating the gemset anymore. So if the gemset doesn't exist, RVM will complain and give instructions on how to create it.
