### PR TITLE
included FactoryGirl stuff in RSpec config per FG docs: https://github.c...

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,4 +51,7 @@ RSpec.configure do |config|
   #config.infer_base_class_for_anonymous_controllers = false
 
   config.include Devise::TestHelpers, :type => :controller
+  
+  config.include FactoryGirl::Syntax::Methods #added per FactoryGirl docs 
+  # https://github.com/thoughtbot/factory_girl/wiki/Usage
 end


### PR DESCRIPTION
...om/thoughtbot/factory_girl/wiki/Usage

added one line here b/c FactoryGirl docs said so:

"Make sure to add this to your RSpec configure block:

RSpec.configure do |config|
  config.include FactoryGirl::Syntax::Methods
end"

https://github.com/thoughtbot/factory_girl/wiki/Usage
