### PR TITLE
Backfill events_controller specs and then refactor events_controller.

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,89 +1,61 @@
 class EventsController < ApplicationController
-  before_filter :authenticate_user!, :except => [:show, :index]
-  before_filter :assign_organizer,   :except => [:new, :create, :index]
-  before_filter :require_organizer,  :only => [:edit, :update, :destroy]
+  before_filter :authenticate_user!, only: [:new, :edit, :create, :update, :destroy]
+  before_filter :find_event, only: [:show, :edit, :update, :destroy]
+  before_filter :require_organizer, only: [:edit, :update, :destroy]
+  before_filter :assign_organizer, only: [:show, :edit, :update, :destroy]
 
   def index
     @events = Event.upcoming
-
-    respond_to do |format|
-      format.html # index.html.erb
-      format.json { render json: @events }
-    end
   end
 
   def show
-    @event ||= Event.find(params[:id])
-    respond_to do |format|
-      format.html # show.html.erb
-      format.json { render json: @event }
-    end
   end
 
   def new
     @event = Event.new
-    respond_to do |format|
-      format.html # new.html.erb
-      format.json { render json: @event }
-    end
   end
 
   def edit
-    @event ||= Event.find(params[:id])
   end
 
   def create
     @event = Event.new(params[:event])
 
-    respond_to do |format|
-      if @event.save
-        @event.organizers << current_user
-        format.html { redirect_to @event, notice: 'Event was successfully created.' }
-        format.json { render json: @event, status: :created, location: @event }
-      else
-        format.html { render action: "new" }
-        format.json { render json: @event.errors, status: :unprocessable_entity }
-      end
+    if @event.save
+      @event.organizers << current_user
+      redirect_to @event, notice: 'Event was successfully created.'
+    else
+      render action: "new"
     end
   end
 
   def update
-    @event ||= Event.find(params[:id])
-
-    respond_to do |format|
-      if @event.update_attributes(params[:event])
-        format.html { redirect_to @event, notice: 'Event was successfully updated.' }
-        format.json { head :ok }
-      else
-        format.html { render status: :unprocessable_entity, action: "edit" }
-        format.json { render json: @event.errors, status: :unprocessable_entity }
-      end
+    if @event.update_attributes(params[:event])
+      redirect_to @event, notice: 'Event was successfully updated.'
+    else
+      render status: :unprocessable_entity, action: "edit"
     end
   end
 
   def destroy
-    @event ||= Event.find(params[:id])
     @event.destroy
-
-    respond_to do |format|
-      format.html { redirect_to events_url }
-      format.json { head :ok }
-    end
+    redirect_to events_url
   end
 
-  private
+  protected
 
   def require_organizer
-    @event ||= Event.find(params[:id])
     unless assign_organizer
       flash[:error] = "You must be an organizer for the event or an Admin to update or delete an event"
       redirect_to events_path # halts request cycle
     end
   end
 
-  def assign_organizer
-    @event ||= Event.find(params[:id])
+  def find_event
+    @event = Event.find(params[:id])
+  end
 
+  def assign_organizer
     if user_signed_in?
       @organizer = @event.organizer?(current_user) || current_user.admin?
     else

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -5,84 +5,243 @@ describe EventsController do
     @event = create(:event)
   end
 
-  describe "permissions" do
-    context "a user that is not logged in" do
-      it "should not be able to create a new event" do
-        get :new
-        response.should redirect_to(new_user_session_path)
-      end
-      it "should not be able to edit an event" do
-        get :edit, {:id => @event.id}
-        response.should redirect_to(new_user_session_path)
-      end
-      it "should not be able to delete an event" do
-        delete :destroy, {:id => @event.id}
-        response.should redirect_to(new_user_session_path)
-      end
+  describe "GET index" do
+    it "succeeds" do
+      get :index
+      response.should be_success
     end
 
-    context "a user that is logged in" do
+    it "assigns upcoming events" do
+      get :index
+      assigns(:events).should == [@event]
+    end
+  end
+
+  describe "GET show" do
+    it "succeeds" do
+      get :show, id: @event.id
+      response.should be_success
+    end
+
+    it "assigns the event" do
+      get :show, id: @event.id
+      assigns(:event).should == @event
+    end
+  end
+
+  describe "GET new" do
+    def make_request
+      get :new
+    end
+
+    it_behaves_like "an action that requires user log-in"
+
+    context "when a user is logged in" do
       before do
         @user = create(:user)
         sign_in @user
       end
-      it "should be able to create a new event" do
+
+      it "succeeds" do
         get :new
         response.should be_success
+      end
 
-        create_params = {
-          "event" => {
-            "title" => "asdfasdfasdf", 
-            "event_sessions_attributes" => {
-              "0" => {
-                "starts_at(1i)" => "2013", 
-                "starts_at(2i)" => "1", 
-                "starts_at(3i)" => "12", 
-                "starts_at(4i)" => "12", 
-                "starts_at(5i)" => "30", 
-                "ends_at(1i)" => "2013", 
-                "ends_at(2i)" => "1", 
-                "ends_at(3i)" => "12", 
-                "ends_at(4i)" => "22", 
-                "ends_at(5i)" => "30"
-              }
-            }, 
-            "location_id"=>"1", 
-            "details"=>"sdfasdfasdf"
+      it "assigns an event" do
+        get :new
+        assigns(:event).should be_new_record
+      end
+    end
+  end
+
+  describe "GET edit" do
+    def make_request
+      get :edit, :id => @event.id
+    end
+
+    it_behaves_like "an event action that requires an organizer"
+
+    context "organizer is logged in" do
+      before do
+        user = create(:user)
+        @event.organizers << user
+        sign_in user
+      end
+
+      it "succeeds" do
+        make_request
+        response.should be_success
+      end
+
+      it "assigns the event" do
+        make_request
+        assigns(:event).should == @event
+      end
+    end
+  end
+
+  describe "POST create" do
+    def make_request(params = {})
+      post :create, params
+    end
+
+    it_behaves_like "an action that requires user log-in"
+
+    context "when a user is logged in" do
+      before do
+        @user = create(:user)
+        sign_in @user
+      end
+
+      describe "with valid params" do
+        let(:create_params) {
+          {
+            "event" => {
+              "title" => "asdfasdfasdf",
+              "event_sessions_attributes" => {
+                "0" => {
+                  "starts_at(1i)" => "2013",
+                  "starts_at(2i)" => "1",
+                  "starts_at(3i)" => "12",
+                  "starts_at(4i)" => "12",
+                  "starts_at(5i)" => "30",
+                  "ends_at(1i)" => "2013",
+                  "ends_at(2i)" => "1",
+                  "ends_at(3i)" => "12",
+                  "ends_at(4i)" => "22",
+                  "ends_at(5i)" => "30"
+                }
+              },
+              "location_id" => "1",
+              "details" => "sdfasdfasdf"
+            }
           }
         }
 
-        expect { 
-          post :create, create_params 
-        }.to change(Event, :count).by(1)
-      end
-      
-      it "should be not be able to edit an event the user is not an organizer of" do
-        get :edit, {:id => @event.id}
-        response.should_not be_success
+        it "creates a new event" do
+          expect {
+            make_request(create_params)
+          }.to change(Event, :count).by(1)
+        end
 
-        put :update, {:id => @event.id}
-        response.should_not be_success
-      end
+        it "adds the current user to the organizers of the event" do
+          make_request(create_params)
+          Event.last.organizers.should include(@user)
+        end
 
-      it "should be able to edit an event when the user is an organizer of the event" do
-        @event.organizers << @user
+        it "redirects to the new event's page" do
+          make_request(create_params)
+          response.should redirect_to event_path(Event.last)
+        end
 
-        get :edit, {:id => @event.id}
-        response.should be_success
-
-        put :update, {:id => @event.id}
-        response.should redirect_to(event_path(@event))
-      end
-
-      it "should not be able to delete a event if they are not an organizer of the event" do
-        expect { delete :destroy, {:id => @event.id} }.to change(Event, :count).by(0)
+        it "shows a success message" do
+          make_request(create_params)
+          flash[:notice].should_not be_empty
+        end
       end
 
-      it "should be able to delete a event if they are an organizer of the event" do
-        @event.organizers << @user
+      describe "with invalid params" do
+        it "does not create an event" do
+          expect { make_request }.to_not change { Event.count }
+        end
 
-        expect { delete :destroy, {:id => @event.id} }.to change(Event, :count).by(-1)
+        it "assigns the event" do
+          make_request
+          assigns(:event).should be_new_record
+        end
+
+        it "renders the new page" do
+          make_request
+          response.should be_success
+          response.should render_template('events/new')
+        end
+      end
+    end
+  end
+
+  describe "PUT update" do
+    def make_request(params = {})
+      put :update, id: @event.id, event: params
+    end
+
+    it_behaves_like "an event action that requires an organizer"
+
+    context "organizer is logged in" do
+      before do
+        user = create(:user)
+        @event.organizers << user
+        sign_in user
+      end
+
+      describe "with valid params" do
+        let(:update_params) {
+          {
+            "title" => "Updated event title",
+            "details" => "Updated event details"
+          }
+        }
+
+        it "updates the event" do
+          make_request(update_params)
+          @event.reload
+          @event.title.should == "Updated event title"
+          @event.details.should == "Updated event details"
+        end
+
+        it "redirects to the event page" do
+          make_request(update_params)
+          response.should redirect_to event_path(@event)
+        end
+
+        it "shows a success message" do
+          make_request(update_params)
+          flash[:notice].should_not be_empty
+        end
+      end
+
+      describe "with invalid params" do
+        let(:invalid_params) {
+          {
+            "title" => ""
+          }
+        }
+
+        it "assigns the event" do
+          make_request(invalid_params)
+          assigns(:event).should == @event
+        end
+
+        it "renders the edit form" do
+          make_request(invalid_params)
+          response.should be_unprocessable
+          response.should render_template('events/edit')
+        end
+      end
+    end
+  end
+
+  describe "DELETE destroy" do
+    def make_request
+      delete :destroy, :id => @event.id
+    end
+
+    it_behaves_like "an event action that requires an organizer"
+
+    context "organizer is logged in" do
+      before do
+        user = create(:user)
+        @event.organizers << user
+        sign_in user
+      end
+
+      it "destroys the event" do
+        make_request
+        Event.find_by_id(@event.id).should == nil
+      end
+
+      it "redirects to the events page" do
+        make_request
+        response.should redirect_to events_path
       end
     end
   end

--- a/spec/support/authorization_shared_behaviors.rb
+++ b/spec/support/authorization_shared_behaviors.rb
@@ -1,0 +1,19 @@
+shared_examples_for "an action that requires user log-in" do
+  it "does not allow access to anonymous users" do
+    make_request
+    response.should redirect_to(new_user_session_path)
+  end
+end
+
+shared_examples_for "an event action that requires an organizer" do
+  it "does not allow access to anonymous users" do
+    make_request
+    response.should redirect_to(new_user_session_path)
+  end
+
+  it "does not allow access to users who aren't organizers of the event" do
+    sign_in(create(:user))
+    make_request
+    response.should redirect_to(events_path)
+  end
+end


### PR DESCRIPTION
When @jesses16 and I were adding event sessions, we noticed that there was a lot of unused and untested code in the events controller. This changeset backfills all the missing specs and then simplifies the controller itself.
