### PR TITLE
Interactive rebase doesn't have prompt strings.

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,15 +54,15 @@
 		</ul>
 		<p>This will open up an editor that shows you your commits that aren't on the upstream master:</p>
 		<ul>
-			<li>$ pick jfd834sf set textbox width better</li>
-			<li>$ pick 92urw73 fix bad choices</li>
-			<li>$ pick dj57skg add html editing</li>
+			<li>pick jfd834sf set textbox width better</li>
+			<li>pick 92urw73 fix bad choices</li>
+			<li>pick dj57skg add html editing</li>
 		</ul>
 		<p>Edit these so that that all but one say squash instead of pick:</p>
 		<ul>	
-			<li>$ pick jfd834sf set textbox width better</li>
-			<li>$ squash 92urw73 fix bad choices</li>
-			<li>$ squash dj57skg add html editing</li>
+			<li>pick jfd834sf set textbox width better</li>
+			<li>squash 92urw73 fix bad choices</li>
+			<li>squash dj57skg add html editing</li>
 		</ul>
 		<p>Save and quit this, and you'll get a new editor that you can use to create the perfect commit message. Save and quit once you've written it, and you've got one nice commit on top of the most recent updates to the project.</p>
 		<h2>Submit that pull request!</h2>


### PR DESCRIPTION
Removes the prompt strings from the rebase examples since they don't appear in the editor.
