### PR TITLE
Add reminder emails for volunteers

### DIFF
--- a/app/jobs/reminder_sender.rb
+++ b/app/jobs/reminder_sender.rb
@@ -1,0 +1,27 @@
+class ReminderSender
+  def self.send_all_reminders
+    UpcomingEventsQuery.new.find_each do |event|
+      remind_volunteers_for(event)
+    end
+  end
+
+  def self.remind_volunteers_for(event)
+    event.volunteer_rsvps.where(:reminded_at => nil).find_each do |rsvp|
+      RsvpMailer.volunteer_reminder(rsvp).deliver
+      rsvp.update_attributes(reminded_at: Time.now)
+    end
+  end
+end
+
+class UpcomingEventsQuery
+  def initialize(relation = Event.scoped)
+    @relation = relation
+  end
+
+  def find_each(&block)
+    @relation
+      .where("events.starts_at > ?", Time.zone.now)
+      .where("events.starts_at < ?", Time.zone.now + 3.days)
+      .find_each(&block)
+  end
+end

--- a/app/mailers/rsvp_mailer.rb
+++ b/app/mailers/rsvp_mailer.rb
@@ -4,14 +4,20 @@ class RsvpMailer < ActionMailer::Base
 
   def send_confirmation(rsvp)
     if rsvp.role == Role::VOLUNTEER
-      confirm_volunteer(rsvp)
+      volunteer_email(rsvp,  'Thanks for volunteering with Railsbridge!')
     end
   end
 
-  def confirm_volunteer(rsvp)
+  def volunteer_reminder(rsvp)
+    volunteer_email(rsvp, "Reminder: You're volunteering with Railsbridge")
+  end
+
+  private
+
+  def volunteer_email(rsvp, subject)
     @rsvp = rsvp
     mail(
-      to: rsvp.user.email, subject: 'Thanks for volunteering with Railsbridge!',
+      to: rsvp.user.email, subject: subject,
       template_name: 'confirm_volunteer'
     )
   end

--- a/db/migrate/20130424215722_add_reminded_at_to_rsvps.rb
+++ b/db/migrate/20130424215722_add_reminded_at_to_rsvps.rb
@@ -1,0 +1,5 @@
+class AddRemindedAtToRsvps < ActiveRecord::Migration
+  def change
+    add_column :rsvps, :reminded_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130419053546) do
+ActiveRecord::Schema.define(:version => 20130424215722) do
 
   create_table "event_sessions", :force => true do |t|
     t.datetime "starts_at"
@@ -101,6 +101,7 @@ ActiveRecord::Schema.define(:version => 20130419053546) do
     t.text     "job_details"
     t.integer  "class_level"
     t.integer  "checkins_count",                         :default => 0
+    t.datetime "reminded_at"
   end
 
   add_index "rsvps", ["user_id", "event_id", "user_type"], :name => "index_rsvps_on_user_id_and_event_id_and_event_type", :unique => true

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,0 +1,6 @@
+desc "This task is called by the Heroku scheduler add-on"
+task :send_reminders => :environment do
+  puts "Sending emails to volunteers..."
+  ReminderSender.send_all_reminders
+  puts "...done."
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :user do
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
-    sequence(:email) { |n| "example#{n}@example.com"}
+    sequence(:email) { |n| "example#{n}@example.com" }
     confirmed_at DateTime.now
     password "password"
   end
@@ -16,11 +16,13 @@ FactoryGirl.define do
     sequence(:title) { |n| "Event #{n}" }
     details "This is note in the details attribute."
     time_zone "Hawaii"
+    starts_at DateTime.now
+    ends_at { starts_at + 1.day }
 
     factory :event do
       location
       before(:create) do |event, evaluator|
-        event.event_sessions << build(:event_session, event: event)
+        event.event_sessions << build(:event_session, event: event, starts_at: event.starts_at, ends_at: event.ends_at)
       end
     end
   end
@@ -30,7 +32,7 @@ FactoryGirl.define do
     sequence(:address_1) { |n| "#{n} Street" }
     city "San Francisco"
   end
-  
+
   factory :event_session do
     sequence(:name) { |n| "Test Session #{n}" }
     starts_at DateTime.now
@@ -42,7 +44,7 @@ FactoryGirl.define do
   end
 
   factory :rsvp, aliases: [:volunteer_rsvp] do
-    user 
+    user
     event
     role Role.find_by_title('Volunteer')
     teaching_experience "Quite experienced"
@@ -59,5 +61,5 @@ FactoryGirl.define do
   factory :rsvp_session do
     rsvp
     event_session
-  end 
+  end
 end

--- a/spec/jobs/reminder_sender_spec.rb
+++ b/spec/jobs/reminder_sender_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+describe ReminderSender do
+  describe '.send_all' do
+    it 'sends the reminders for each of the upcoming events' do
+      upcoming_event = create(:event, starts_at: Time.now + 1.day)
+      past_event = create(:event, starts_at: Time.now - 1.day)
+      ReminderSender.should_receive(:remind_volunteers_for, upcoming_event)
+      ReminderSender.should_not_receive(:remind_volunteers_for).with(past_event)
+      ReminderSender.send_all_reminders
+    end
+  end
+
+  describe '.remind_volunteers_for' do
+    let(:event) { create(:event) }
+    let!(:volunteer_rsvp) { create(:volunteer_rsvp, :event => event) }
+    let!(:reminded_volunteer_rsvp) { create(:volunteer_rsvp, :reminded_at => Time.now, :event => event) }
+
+    it 'sends emails to all the volunteers' do
+      pending_reminder_count = event.volunteer_rsvps.where('reminded_at NOT NULL').count
+      expect {
+        ReminderSender.remind_volunteers_for(event)
+      }.to change(ActionMailer::Base.deliveries, :count).by(pending_reminder_count)
+    end
+
+    it 'updates reminded_at' do
+      expect {
+        ReminderSender.remind_volunteers_for(event)
+      }.to change { volunteer_rsvp.reload.reminded_at.present? }.to(true)
+    end
+  end
+end
+
+describe UpcomingEventsQuery do
+  let(:events) { UpcomingEventsQuery.new }
+
+  it 'includes events in the next three days' do
+    event_tomorrow = create(:event, starts_at: Time.now + 1.day)
+    found = false
+    events.find_each { |event| found = true if event_tomorrow == event }
+    found.should be_true
+  end
+
+  it 'doesnt include events in the far future' do
+    event_four_days_away = create(:event, starts_at: Time.now + 4.days)
+    events.find_each { |event| event.should_not eq(event_four_days_away) }
+  end
+
+  it 'doesnt include events in the past' do
+    past_event = create(:event, starts_at: Time.now - 1.day)
+    events.find_each { |event| event.should_not eq(past_event) }
+  end
+end

--- a/spec/mailers/rsvp_mailer_spec.rb
+++ b/spec/mailers/rsvp_mailer_spec.rb
@@ -40,5 +40,20 @@ describe RsvpMailer do
       end
     end
   end
+
+  describe 'the reminder email' do
+    let(:rsvp) { FactoryGirl.create(:rsvp) }
+    let(:event) { rsvp.event }
+    let(:mail) { RsvpMailer.volunteer_reminder(rsvp) }
+
+    it 'has the right headers' do
+      mail.subject.should eq("Reminder: You're volunteering with Railsbridge")
+      mail.to.should eq([rsvp.user.email])
+      mail.from.should eq(['troll@bridgetroll.org'])
+      mail.body.should_not be_empty
+    end
+
+    it_behaves_like 'a mailer view'
+  end
 end
 


### PR DESCRIPTION
This PR adds a rake task that sends a reminder to a volunteer for an event. (`rake send_reminders`)

We will still need to set up the cron job to run every day using Heroku scheduler. (see https://devcenter.heroku.com/articles/scheduler)

Related story: https://www.pivotaltracker.com/story/show/41278311
