### PR TITLE
Unauthenticated user sees greyed-out form with signin modal when RSVPing

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -32,4 +32,8 @@ $(document).ready(function () {
   if ($(window).height() < $('html').height()) {
     $('footer').show();
   }
+
+  if ($('body').data('prompt-login')) {
+    $("#sign_in_dialog").modal();
+  }
 });

--- a/app/assets/javascripts/sign_in.js.coffee
+++ b/app/assets/javascripts/sign_in.js.coffee
@@ -1,15 +1,2 @@
 $ ->
   $("#sign_in_dialog").modal('hide')
-  $(document).on 'click.modal.data-api', '[data-toggle="modal"]', (e) ->
-    $link = $(e.target)
-    $modal = $($link.attr('href'))
-    return_to_link = $link.data('returnTo')
-
-    url = document.createElement('a');
-    url.href = $modal.find('form').attr('action');
-    if return_to_link
-      url.search = 'return_to=' + encodeURIComponent(return_to_link)
-    else
-      url.search = null
-
-    $modal.find('form').attr('action', url.pathname + url.search)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  before_filter :store_location
+
   protect_from_forgery
 
   def validate_organizer!
@@ -11,7 +13,16 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def store_location
+    # store last url as long as it isn't a /users path
+    session[:previous_url] = request.fullpath unless request.fullpath =~ /\/users/
+  end
+
   def after_sign_in_path_for(resource)
-    params[:return_to] || super
+    session[:previous_url] || root_path
+  end
+
+  def prompt_login
+    @prompt_login = !current_user
   end
 end

--- a/app/controllers/rsvps_controller.rb
+++ b/app/controllers/rsvps_controller.rb
@@ -1,5 +1,6 @@
 class RsvpsController < ApplicationController
-  before_filter :authenticate_user!
+  before_filter :authenticate_user!, :except => [:volunteer, :learn]
+  before_filter :prompt_login, :only => [:volunteer, :learn]
   before_filter :assign_event
   before_filter :load_rsvp, except: [:volunteer, :learn, :create]
 

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -9,4 +9,4 @@
 </td>
 <td><%= formatted_session_date(event.event_sessions.first) %></td>
 <td><%= formatted_session_timerange(event.event_sessions.first) %></td>
-<td><%= event.location.name rescue nil %></td>
+<td><%= event.location.try(:name) %></td>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -11,31 +11,30 @@
         <th>RSVP</th>
       </tr>
 
-      <% if @events.length == 0 %>
-        <tr>
-          <td colspan="5">There are no events.</td>
-        </tr>
+      <% if @events.empty? %>
+          <tr>
+            <td colspan="5">There are no events.</td>
+          </tr>
       <% end %>
-      <% @events.each do |event| %>
-        <tr>
-          <%= render 'event', event: event %>
-          <td>
-            <% if user_signed_in? %>
-              <% if event.organizer?(current_user) || current_user.admin? %>
-                <div><%= link_to 'Organizer Console', organize_event_path(event), :class => 'btn' %></div>
+      <% @events.find_each do |event| %>
+          <tr>
+            <%= render 'event', event: event %>
+            <td>
+              <% if user_signed_in? && (event.organizer?(current_user) || current_user.admin?) %>
+                  <div><%= link_to 'Organizer Console', organize_event_path(event), :class => 'btn' %></div>
               <% end %>
               <%= render 'shared/rsvp_actions', event: event %>
-            <% else %>
-              <a href="#sign_in_dialog" class="btn" data-toggle="modal" data-return-to="<%= event_path(event) %>">Learn</a>
-              <a href="#sign_in_dialog" class="btn" data-toggle="modal" data-return-to="<%= event_path(event) %>">Volunteer</a>
-            <% end %>
-          </td>
-        </tr>
+            </td>
+          </tr>
       <% end %>
     </table>
 
     <h1>Past events</h1>
-    <table class="<%= @past_events.length > 0 ? 'datatable-sorted' : '' %> table table-striped table-bordered table-condensed">
+    <table class="<%= if @past_events.any? then
+                        'datatable-sorted'
+                      else
+                        ''
+                      end %> table table-striped table-bordered table-condensed">
       <thead>
       <tr>
         <th>Title</th>
@@ -46,22 +45,22 @@
       </thead>
 
       <tbody>
-      <% if @past_events.length == 0 %>
-        <tr>
-          <td colspan="5">There are no past events.</td>
-        </tr>
+      <% if @past_events.empty? %>
+          <tr>
+            <td colspan="5">There are no past events.</td>
+          </tr>
       <% end %>
-      <% @past_events.each do |event| %>
-        <tr><%= render 'event', event: event %></tr>
+      <% @past_events.find_each do |event| %>
+          <tr><%= render 'event', event: event %></tr>
       <% end %>
       </tbody>
     </table>
 
     <% if user_signed_in? %>
-      <%= render 'shared/actions', links: [
-        ['Organize Event', new_event_path],
-        ['Manage Locations', locations_path]
-      ] %>
+        <%= render 'shared/actions', links: [
+                ['Organize Event', new_event_path],
+                ['Manage Locations', locations_path]
+        ] %>
     <% end %>
 
   </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -47,9 +47,7 @@
     </div>
 
     <div class='rsvp-actions'>
-      <% if user_signed_in? %>
         <%= render 'shared/rsvp_actions', event: @event %>
-      <% end %>
     </div>
 
     <div class="organizers">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
     <%= csrf_meta_tags %>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
   </head>
-  <body>
+  <%= content_tag "body", data: {prompt_login: @prompt_login} do %>
     <div class="navbar navbar-fixed-top">
       <div class="navbar-inner">
         <a class="app-name" href=<%= events_path %>><%= render 'shared/logo' %></a>
@@ -37,6 +37,6 @@
       <%= yield :scripts %>
     </div>
     <footer><div class="trollholder"><%= render 'shared/troll' %></div></footer>
-  </body>
+  <% end %>
   <%= render 'shared/sign_in_dialog' %>
 </html>

--- a/app/views/shared/_rsvp_actions.html.erb
+++ b/app/views/shared/_rsvp_actions.html.erb
@@ -1,14 +1,17 @@
-<% if event.volunteer?(current_user) %>
-  <div class='rsvp-text'>You are signed up to volunteer for this event!</div>
+<% if user_signed_in? %>
+    <% if event.volunteer?(current_user) %>
+        <div class='rsvp-text'>You are signed up to volunteer for this event!</div>
+    <% elsif event.student?(current_user) %>
+        <div class='rsvp-text'>You are signed up to attend this event!</div>
+    <% end %>
+
+    <% if event.student?(current_user) || event.volunteer?(current_user) %>
+        <%= link_to 'Edit RSVP', edit_event_rsvp_path(event, event.rsvp_for_user(current_user)), :class => 'btn' %>
+        <%= link_to 'Cancel RSVP', event_rsvp_path(event, event.rsvp_for_user(current_user)), data: {confirm: 'Are you sure you want to cancel your RSVP?'}, method: :delete, class: 'btn' %>
+    <% end %>
 <% end %>
-<% if event.student?(current_user) %>
-  <div class='rsvp-text'>You are signed up to attend this event!</div>
-<% end %>
-<% if event.student?(current_user) || event.volunteer?(current_user) %>
-  <%= link_to 'Edit RSVP', edit_event_rsvp_path(event, event.rsvp_for_user(current_user)), :class => 'btn' %>
-  <%= link_to 'Cancel RSVP', event_rsvp_path(event, event.rsvp_for_user(current_user)), data: {confirm: 'Are you sure you want to cancel your RSVP?'}, method: :delete, class: 'btn' %>
-<% end %>
-<% if event.no_rsvp?(current_user) %>
+
+<% if !user_signed_in? || event.no_rsvp?(current_user) %>
   <% unless ENV['DISABLE_STUDENT_RSVP'] %>
     <%= link_to 'Learn', learn_new_event_rsvp_path(event), :method => :get, :class => 'btn' %>
   <% end %>

--- a/spec/controllers/rsvps_controller_spec.rb
+++ b/spec/controllers/rsvps_controller_spec.rb
@@ -140,7 +140,8 @@ describe RsvpsController do
       before do
         @rsvp = create(:rsvp)
       end
-      it "should destroy the rsvp" do
+
+      it "destroys the rsvp" do
         expect {
           delete :destroy, event_id: @rsvp.event.id, id: @rsvp.id
         }.to change {Rsvp.count }.by(-1)
@@ -151,11 +152,11 @@ describe RsvpsController do
       end
     end
 
-    context "there is no rsvp record for this user at this event" do
-      it "should notify the user s/he has not signed up to volunteer for the event" do
+    context "the user has not signed up for this event" do
+      it "notifies the user s/he has not signed up to volunteer for the event" do
         expect {
-          delete :destroy, event_id: 3298423, id: 29101
-        }.to change {Rsvp.count }.by(0)
+          delete :destroy, event_id: Event.first.to_param, id: 1234
+        }.not_to change(Rsvp, :count)
         flash[:notice].should match(/You are not signed up/i)
       end
     end

--- a/spec/features/event_listing_request_spec.rb
+++ b/spec/features/event_listing_request_spec.rb
@@ -50,10 +50,10 @@ describe "the event listing page" do
         fill_in "Password", with: @user.password
         click_button "Sign in"
       end
-      current_path.should == event_path(event)
+      current_path.should == learn_new_event_rsvp_path(event)
     end
   end
-
+  
   context 'as a logged in user' do
     before(:each) do
       @user = create(:user)


### PR DESCRIPTION
With this change:
When an unauthenticated user clicks on a Learn/Volunteer RSVP button, they see a greyed out RSVP form with a signin modal.

Before:
When an unauthenticated user clicks on a Learn/Volunteer RSVP button, they see the login modal immediately, and upon signing in, they are redirected to the event page.

Related story: https://www.pivotaltracker.com/story/show/41850205
