### PR TITLE
Prompt user to connect Meetup.com account

### DIFF
--- a/app/assets/javascripts/alerts.js.coffee
+++ b/app/assets/javascripts/alerts.js.coffee
@@ -1,0 +1,4 @@
+$(document).ready ->
+  $(".alert form.button_to").bind "ajax:success", (event, data, status, xhr) ->
+    $(event.target).closest(".alert").remove()
+    

--- a/app/assets/stylesheets/_base.css.scss
+++ b/app/assets/stylesheets/_base.css.scss
@@ -46,10 +46,6 @@ textarea {
   width: 500px;
 }
 
-a {
-  color: #22444D;
-}
-
 .field {
   margin-bottom: 20px;
 }
@@ -180,17 +176,21 @@ td.wide {
   width: auto; display:inline;
 }
 
-.meetup-association {
-  border: 3px solid rgb(80, 80, 97);
+.alert-action-needed {
+  border-color: rgb(80, 80, 97);
   background-color: rgb(200, 200, 200);
-  width: 500px;
-  margin: 0 auto;
-  text-align: center;
-  padding: 15px;
-  border-radius: 10px;
+  color: rgb(51, 51, 51);
+  text-shadow: none;
 }
 
 // BOOTSTRAP OVERRIDES, Yo. Frowny buckets.
+.alert .button_to {
+  float: right;
+}
+
+.alert .close {
+  border:none;
+}
 
 .container::before,
 .container::after { display: block; }

--- a/app/controllers/users/meetup_prompts_controller.rb
+++ b/app/controllers/users/meetup_prompts_controller.rb
@@ -1,0 +1,9 @@
+module Users
+  class MeetupPromptsController < ApplicationController
+    def destroy
+      @meetup_prompt = MeetupPrompt.build(current_user)
+      @meetup_prompt.destroy if @meetup_prompt
+      head :ok
+    end
+  end
+end

--- a/app/models/meetup_prompt.rb
+++ b/app/models/meetup_prompt.rb
@@ -1,0 +1,20 @@
+class MeetupPrompt
+  def self.build(user)
+    return if !user || user.meetup_id || user.meetup_prompt_dismissed
+
+    new(user)
+  end
+
+  def initialize(user)
+    @user = user
+  end
+
+  def path
+    "/users/#{@user.id}/meetup_prompt"
+  end
+
+  def destroy
+    @user.meetup_prompt_dismissed = true
+    @user.save
+  end
+end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,17 +1,5 @@
 <h1>Edit <%= resource_name.to_s.humanize %></h1>
 
-<div class='meetup-association'>
-
-  <% if resource.meetup_id.present? %>
-    <p>This account is associated with <%= link_to "meetup user #{resource.meetup_id}.", "http://www.meetup.com/members/#{resource.meetup_id}/" %></p>
-  <% else %>
-    <p>This account is not associated with a SFRuby Meetup account.</p>
-
-    <p>If you associate with your meetup account, Bridgetroll can show you information about past workshops you have attended.</p>
-    <%= link_to 'Associate with Meetup account', "/auth/meetup", class: 'btn' %>
-  <% end %>
-</div>
-
 <%= render 'shared/profile_gravatars'%>
 
 <%= form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put }) do |f| %>
@@ -55,11 +43,23 @@
   </div>
 
   <div><%= f.submit "Update" %></div>
+
+  <hr>
+  <div>
+    <%= label_tag :meetup_id, 'Associated Meetup Account' %>
+    <% if resource.meetup_id %>
+        Currently associated
+        with <%= link_to "Meetup user #{resource.meetup_id}.", "https://www.meetup.com/members/#{resource.meetup_id}/" %></p>
+    <% else %>
+        <p>You haven't connected your Meetup.com account yet! :(</p>
+        <p>Connect your Meetup.com account to import information about past workshops you have attended.</p>
+        <%= link_to 'Connect to Meetup.com', "/auth/meetup", class: 'btn' %>
+    <% end %>
+  </div>
 <% end %>
 
-<h3>Cancel my account</h3>
 
-<p>Unhappy? <%= link_to "Cancel my account", registration_path(resource_name), :confirm => "Are you sure?", :method => :delete %>.</p>
+<p><%= link_to "Delete my account", registration_path(resource_name), :confirm => "Are you sure?", :method => :delete %></p>
 
 <%= link_to "Back", :back %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,6 +33,8 @@
             <%= msg  %>
           </div>
       <% end %>
+      <%= render partial: 'users/meetup_prompt' %>
+
       <%= yield %>
       <%= yield :scripts %>
     </div>

--- a/app/views/users/_meetup_prompt.html.erb
+++ b/app/views/users/_meetup_prompt.html.erb
@@ -1,0 +1,8 @@
+<% meetup_prompt = MeetupPrompt.build(current_user) %>
+<% if meetup_prompt %>
+    <div class="alert alert-action-needed">
+      <%= button_to '&times;'.html_safe, meetup_prompt.path, remote: true, method: :delete, class: 'close', data: {dismiss: 'alert'} %>
+      Connect your Meetup.com account to import information about past workshops you have attended.
+      <%= link_to 'Connect to Meetup.com', "/auth/meetup", class: 'btn' %>
+    </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Bridgetroll::Application.routes.draw do
 
   resources :users, only: [:index] do
     resource :profile, :only => [:edit, :update, :show]
+    resource :meetup_prompt, :only => [:destroy], :controller => 'users/meetup_prompts'
   end
   resources :meetup_users, :only => [:show]
 

--- a/db/migrate/20130505083029_add_meetup_prompt_dismissed_to_users.rb
+++ b/db/migrate/20130505083029_add_meetup_prompt_dismissed_to_users.rb
@@ -1,0 +1,5 @@
+class AddMeetupPromptDismissedToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :meetup_prompt_dismissed, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130424215722) do
+ActiveRecord::Schema.define(:version => 20130505083029) do
 
   create_table "event_sessions", :force => true do |t|
     t.datetime "starts_at"
@@ -107,12 +107,12 @@ ActiveRecord::Schema.define(:version => 20130424215722) do
   add_index "rsvps", ["user_id", "event_id", "user_type"], :name => "index_rsvps_on_user_id_and_event_id_and_event_type", :unique => true
 
   create_table "users", :force => true do |t|
-    t.string   "email",                  :default => "",    :null => false
-    t.string   "encrypted_password",     :default => "",    :null => false
+    t.string   "email",                   :default => "",    :null => false
+    t.string   "encrypted_password",      :default => "",    :null => false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          :default => 0
+    t.integer  "sign_in_count",           :default => 0
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
@@ -120,13 +120,14 @@ ActiveRecord::Schema.define(:version => 20130424215722) do
     t.string   "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
-    t.datetime "created_at",                                :null => false
-    t.datetime "updated_at",                                :null => false
-    t.boolean  "admin",                  :default => false
+    t.datetime "created_at",                                 :null => false
+    t.datetime "updated_at",                                 :null => false
+    t.boolean  "admin",                   :default => false
     t.string   "first_name"
     t.string   "last_name"
     t.integer  "meetup_id"
     t.string   "time_zone"
+    t.boolean  "meetup_prompt_dismissed"
   end
 
   add_index "users", ["confirmation_token"], :name => "index_users_on_confirmation_token", :unique => true

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe UsersController do
   before do
-    sign_in_stub double('user', id: 1234)
+    sign_in_stub double('user', id: 1234, meetup_id: 1)
   end
 
   describe "index" do

--- a/spec/features/homepage_request_spec.rb
+++ b/spec/features/homepage_request_spec.rb
@@ -44,5 +44,14 @@ describe "visiting the home page" do
       page.should_not have_link("Sign Up")
       page.should have_link("Profile")
     end
+
+    it 'is prompted to connect their meetup account' do
+      visit '/'
+      within '.alert' do
+        page.should have_link 'Connect to Meetup.com'
+        click_button '×'
+      end
+      page.should_not have_link 'Connect to Meetup.com'
+    end
   end
 end


### PR DESCRIPTION
The user now sees a prompt when they do not have a Meetup account connected. They can dismiss the prompt permanently:
![screen shot 2013-05-05 at 2 17 04 am](https://f.cloud.github.com/assets/1108361/463468/8fa44fec-b564-11e2-9af8-163fabe8f680.png)

I also improved the Profile page by putting the Meetup account stuff into a separate section:
![screen shot 2013-05-05 at 2 19 17 am](https://f.cloud.github.com/assets/1108361/463470/df425a62-b564-11e2-8ffd-cd5f7d27a35f.png)

Related story:
https://www.pivotaltracker.com/story/show/41276811
