### PR TITLE
Specify date type for sorting purposes

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -23,10 +23,13 @@ $(document).ready(function () {
     "iDisplayLength": 50
   } );
 
-  $('.datatable').dataTable();
-
   $('.datatable-sorted').dataTable({
-    "aaSorting": [[ 1, "desc" ]]
+    "aaSorting": [[ 1, "desc" ]],
+    "aoColumns": [
+      null,
+      { "sType": "date" },
+      null
+    ]
   });
 
   if ($(window).height() < $('html').height()) {


### PR DESCRIPTION
This tells datatable to run `Date.parse()` on the Date column before sorting it. It's the simplest way to get that column sorted as a date, but is very dependent on the view to succeed. A more flexible solution would be to use an html5 time tag with a datetime attribute and sort on the standardized time rather than the displayed time. However, that requires that html5 things mostly work on Bridge Troll and it also requires us to write a custom datatable sorting extension.

Is there a way to test this functionality using :ghost:phantomjs? If there is, I'd like to add those tests and keep this low-tech implementation until there's breakage.

Thoughts and feels?
