### PR TITLE
Add dietary restriction field to RSVPs.

### DIFF
--- a/app/views/rsvps/_form.html.erb
+++ b/app/views/rsvps/_form.html.erb
@@ -62,6 +62,11 @@
   </div>
 
   <div class="field">
+    <%= f.label :dietary_info, "Do you have any dietary restrictions? What don't you / won't you eat?" %>
+    <%= f.text_field :dietary_info %>
+  </div>
+
+  <div class="field">
     <%= f.label :needs_childcare, class: 'checkbox' do %>
       <%= f.check_box :needs_childcare %> Do you need childcare?
     <% end %>

--- a/db/migrate/20130528181554_add_dietary_info_to_rsvps.rb
+++ b/db/migrate/20130528181554_add_dietary_info_to_rsvps.rb
@@ -1,0 +1,5 @@
+class AddDietaryInfoToRsvps < ActiveRecord::Migration
+  def change
+    add_column :rsvps, :dietary_info, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130522013935) do
+ActiveRecord::Schema.define(:version => 20130528181554) do
 
   create_table "event_sessions", :force => true do |t|
     t.datetime "starts_at"
@@ -106,6 +106,7 @@ ActiveRecord::Schema.define(:version => 20130522013935) do
     t.integer  "checkins_count",                         :default => 0
     t.datetime "reminded_at"
     t.integer  "waitlist_position"
+    t.string   "dietary_info"
   end
 
   add_index "rsvps", ["user_id", "event_id", "user_type"], :name => "index_rsvps_on_user_id_and_event_id_and_event_type", :unique => true


### PR DESCRIPTION
As an organizer this is the last key feature that Bridge Troll is outright missing. In this PR is just the RSVP form. The information is not rendered or displayed for organizers yet because I want to send the survey out today. I'll write the other half of this when I need it. (A.K.A Thursday)
