### PR TITLE
A couple of command-line fixes for the How to Git guide.

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 		</ul>
 		<p>You can also do these things in a single command that fetches from the URL tracked by the current branch and immediately tries to merge in the tracked branch:</p>
 		<ul>
-			<li>$ git pull --rebase</li>
+			<li>$ git pull --rebase upstream master</li>
 		</ul>
 	</div>
 	<div id="right">


### PR DESCRIPTION
I tried following the guide; it worked once I added a `cd` and added parameters to `git pull --rebase`.
