### PR TITLE
Removes pagination options from Profile view if there are less than 10 rsvp's - Issue #216

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -33,15 +33,17 @@
 //= require dataTables/jquery.dataTables.bootstrap
 
 $(document).ready(function () {
+  var tableNeedsPagination = $('.datatable-sorted tbody tr').length > 10 ? true : false;
   $.extend( $.fn.dataTable.defaults, {
     "sDom": "<'row-fluid'<'span6'l><'span6'f>r>t<'row-fluid'<'span6'i><'span6'p>>",
     "sPaginationType": "bootstrap",
     "iDisplayLength": 50
-  } );
+  });
 
   $('.datatable').dataTable();
 
   $('.datatable-sorted').dataTable({
+    "bPaginate": tableNeedsPagination,
     "aaSorting": [[ 1, "desc" ]],
     "aoColumnDefs": [
       {'aTargets': ['date'], "sType": "date"}

--- a/spec/features/section_arranger_request_spec.rb
+++ b/spec/features/section_arranger_request_spec.rb
@@ -41,6 +41,7 @@ describe "arranging sections for an event", js: true do
     within '#auto_arrange_choices' do
       page.find("[value='#{@session1.id}']").click
       click_on "Auto-Arrange"
+      sleep 1
     end
 
     page.should_not have_css('.auto-assign-reminder')


### PR DESCRIPTION
I realize that there was still ongoing discussion about whether the threshold for hiding the pagination options should be hidden at 10 or 50 rows, but I figured that I would push up what I have and if the value changes, it's not a huge change (line 36 in application.js). 

This is my first contribution to an open source project, so I recognize I probably have a lot to learn - 

Thanks! 

EDIT: I added the sleep 1 to the spec/features/section_arranger_request_spec.rb to help my build pass on Travis-ci . It also helped me out locally. Not 100 % sure if it's a solid fix for issue #222, but it's worth looking in to. Thanks! 
