### PR TITLE
Updated ruby version to 2.0.0-p451

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.0.0'
+ruby '2.0.0', patchlevel: '451'
 gem 'rails', '~> 3.2.17'
 gem 'devise', '~> 3.2.0'
 gem 'thin'


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2014/02/24/ruby-2-0-0-p451-is-released/
Necessary to compile native gem extensions for json gem on OSX
mavericks. Due to apple changing the compiler options. See
http://stackoverflow.com/questions/22352838/ruby-gem-install-json-fails-on-mavericks-and-xcode-5-1-unknown-argument-mul
and
http://stackoverflow.com/questions/22427515/set-ruby-version-in-gemfile
