### PR TITLE
Add `Intro to iOS` as a Course

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -156,8 +156,7 @@ class Course < ActiveHash::Base
           color: 'blue',
           title: "No Programming Experience",
           level_description: [
-            'Totally new to all programming, including iOS',
-            'Made a webpage before, maybe at a RailsBridge Front End Workshop',
+            'New to programming, including iOS programming',
             'No experience with programming languages other than HTML and CSS',
           ]
         }, {


### PR DESCRIPTION
This PR adds an additional course option in Bridge Troll for an intro to iOS. (Our target is to have an iOS workshop in August.)

I'd love feedback about the breakdown and descriptions of experience levels, from everyone and especially  @nesquena and @timothy1ee.

Closes #258 
