### PR TITLE
when creating new event must check code-of-conduct

### DIFF
--- a/app/assets/javascripts/events.js.coffee
+++ b/app/assets/javascripts/events.js.coffee
@@ -56,6 +56,12 @@ jQuery ->
     $dateField = $field.find('.datepicker')
     setUpDatePicker($dateField)
 
+  cocChanged = ->
+    $el = $('#coc')
+    $('.btn-submit').prop('disabled', !$el[0].checked)
+
+  $('#coc').on('change', cocChanged)
+
   $('.chapter-select').on 'change', (event) ->
     chapterId = $(this).val()
     if (chapterId)

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -13,6 +13,8 @@
         </div>
       <% end %>
 
+
+
       <div class="field">
         <%= f.label :title %>
         <%= f.text_field :title %>
@@ -154,8 +156,12 @@
         <p><b>If you post the event on Meetup for advertising</b>, please make only ONE event <i>(RailsBridge workshop at YOUR_VENUE)</i> and set the RSVP limit to 1 <i>(yourself)</i>. This event should be for publicity only (people who are a member of the Meetup group will get emailed about it) &mdash; you should direct attendees to do their actual registration on this Bridge Troll event.</p>
       <% end %>
 
+      <div class="field">
+        <%= check_box_tag :coc %> I accept the <a href="http://bridgefoundry.org/code-of-conduct/" target="_blank">Code of Conduct</a>  and will communicate it at the beginning of the event
+      </div>
+
       <div class="actions">
-        <%= f.submit class: 'btn btn-submit' %>
+        <%= f.submit class: 'btn btn-submit', disabled: true %>
       </div>
     <% end %>
   </div>

--- a/spec/features/new_event_request_spec.rb
+++ b/spec/features/new_event_request_spec.rb
@@ -28,6 +28,10 @@ describe "New Event" do
     page.should have_field("Student Details")
   end
 
+  it "should have the code of conduct checkbox checked" do
+    page.should have_unchecked_field("coc")
+  end
+
   context 'after clicking "Add a session"', js: true do
     before do
       click_on 'Add a session'
@@ -41,5 +45,15 @@ describe "New Event" do
 
       page.should have_selector(:link, 'Remove Session', visible: false)
     end
+  end
+
+  context 'submit form', js: true do
+
+    it 'requires code of conduct to be checked' do
+      page.should have_button 'Create Event', disabled: true
+      check ("coc")
+      page.should have_button 'Create Event', disabled: false
+    end
+
   end
 end


### PR DESCRIPTION
We decided just add this in the view, because we figured we don't need to refer to it later.  We then used javascript to ensure that the code of conduct is checked.
