### PR TITLE
when creating new event must check code-of-conduct

### DIFF
--- a/app/assets/javascripts/events.js.coffee
+++ b/app/assets/javascripts/events.js.coffee
@@ -56,6 +56,14 @@ jQuery ->
     $dateField = $field.find('.datepicker')
     setUpDatePicker($dateField)
 
+  cocChanged = ->
+    $el = $('#coc')
+    if ($el.length > 0)
+      $('.btn-submit').prop('disabled', !$el[0].checked)
+
+  $('#coc').on('change', cocChanged)
+  cocChanged()
+
   $('.chapter-select').on 'change', (event) ->
     chapterId = $(this).val()
     if (chapterId)

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -13,6 +13,8 @@
         </div>
       <% end %>
 
+
+
       <div class="field">
         <%= f.label :title %>
         <%= f.text_field :title %>
@@ -152,7 +154,11 @@
         <p>Pay particular attention to the <a href="https://github.com/railsbridge/docs/wiki/Workshop-Planning-Tasks">Workshop Planning Tasks</a> page. You're already posting an event on Bridge Troll, which is a thing on that page!</p>
 
         <p><b>If you post the event on Meetup for advertising</b>, please make only ONE event <i>(RailsBridge workshop at YOUR_VENUE)</i> and set the RSVP limit to 1 <i>(yourself)</i>. This event should be for publicity only (people who are a member of the Meetup group will get emailed about it) &mdash; you should direct attendees to do their actual registration on this Bridge Troll event.</p>
+        <div class="field">
+          <%= check_box_tag :coc %> I accept the <a href="http://bridgefoundry.org/code-of-conduct/" target="_blank">Code of Conduct</a>  and will communicate it at the beginning of the event
+        </div>
       <% end %>
+
 
       <div class="actions">
         <%= f.submit class: 'btn btn-submit' %>

--- a/spec/features/event_listing_request_spec.rb
+++ b/spec/features/event_listing_request_spec.rb
@@ -89,7 +89,7 @@ describe "the event listing page" do
 
         select "(GMT-09:00) Alaska", from: 'event_time_zone'
         fill_in "event_details", :with => "This is a note in the detail text box\n With a new line!<script>alert('hi')</script> and a (missing) javascript injection, as well as an unclosed <h1> tag"
-
+        check("coc")
         click_button "Create Event"
 
         page.should have_content("February Workshop")
@@ -121,7 +121,7 @@ describe "the event listing page" do
 
         select "(GMT-09:00) Alaska", from: 'event_time_zone'
         fill_in "event_details", :with => "This is a note in the detail text box\n With a new line!<script>alert('hi')</script> and a (missing) javascript injection, as well as an unclosed <h1> tag"
-
+        check("coc")
         click_button "Create Event"
 
         page.should have_content("Volunteer Work Day")
@@ -147,7 +147,7 @@ describe "the event listing page" do
 
         select "(GMT-09:00) Alaska", from: 'event_time_zone'
         fill_in "event_details", :with => "This is a note in the detail text box\n With a new line!<script>alert('hi')</script> and a (missing) javascript injection, as well as an unclosed <h1> tag"
-
+        check("coc")
         click_button "Create Event"
 
         page.should have_content("This is a Front End workshop. The focus will be on")

--- a/spec/features/new_event_request_spec.rb
+++ b/spec/features/new_event_request_spec.rb
@@ -28,6 +28,10 @@ describe "New Event" do
     page.should have_field("Student Details")
   end
 
+  it "should have the code of conduct checkbox checked" do
+    page.should have_unchecked_field("coc")
+  end
+
   context 'after clicking "Add a session"', js: true do
     before do
       click_on 'Add a session'
@@ -41,5 +45,15 @@ describe "New Event" do
 
       page.should have_selector(:link, 'Remove Session', visible: false)
     end
+  end
+
+  context 'submit form', js: true do
+
+    it 'requires code of conduct to be checked' do
+      page.should have_button 'Create Event', disabled: true
+      check ("coc")
+      page.should have_button 'Create Event', disabled: false
+    end
+
   end
 end


### PR DESCRIPTION
we decided to add a checkbox to the page (and not change the model) since we didn't expect anyone would need to refer to the data -- this is just education for organizers
