### PR TITLE
added CSV download button to organizer console

### DIFF
--- a/app/views/events/organizer_tools/show.html.erb
+++ b/app/views/events/organizer_tools/show.html.erb
@@ -76,6 +76,13 @@
       and volunteers as they arrive so that you can take care of other things.'
     } %>
 
+    <%= render partial: 'shared/organizer_action', locals: {
+      path: event_attendees_path(@event, format: :csv),
+      icon: 'fa fa-download',
+      text: 'Download Attendee Names CSV',
+      tip: 'You can use this to download a list of attendees which can be printed out for the security desk.'
+    } %>
+
     <%= render :partial => 'shared/checkin_event_sessions' %>
 
     <section class='organizer-dashboard-section'>


### PR DESCRIPTION
Per https://www.pivotaltracker.com/n/projects/608983/stories/60033152
This had not been done and was relatively simple. I am not on PT for this project and cannot update PT. 

Added a button to the organizer console to download a printable list for use at the security desk. The function already existed on the attendee page, but was somewhat harder to find. No new functionality, this was purely a UE issue. 
