### PR TITLE
Add RSVP form previews to organizer console

### DIFF
--- a/app/controllers/events/organizer_tools_controller.rb
+++ b/app/controllers/events/organizer_tools_controller.rb
@@ -29,4 +29,18 @@ class Events::OrganizerToolsController < ApplicationController
 
   def diets
   end
+
+  def student_rsvp_preview
+    @rsvp = @event.rsvps.build
+    @rsvp.role = Role::STUDENT
+    @rsvp.event_session_ids = @event.event_sessions.pluck(:id)
+    render "rsvps/new"
+  end
+
+  def volunteer_rsvp_preview
+    @rsvp = @event.rsvps.build
+    @rsvp.role = Role::VOLUNTEER
+    @rsvp.event_session_ids = @event.event_sessions.pluck(:id)
+    render "rsvps/new"
+  end
 end

--- a/app/views/events/_organizer_preworkshop_buttons.html.erb
+++ b/app/views/events/_organizer_preworkshop_buttons.html.erb
@@ -6,6 +6,18 @@
       They will have access to the same actions as you (including this page
       and the event edit page)."
      ],
+     [event_student_rsvp_preview_path(@event),
+      'fa fa-pencil',
+      'Preview Student RSVP Form',
+      "This is what the form the students are filling out looks like. Submitting
+      it won't work because you're already organizing this event. :D"
+     ],
+     [event_volunteer_rsvp_preview_path(@event),
+      'fa fa-pencil',
+      'Preview Volunteer RSVP Form',
+      "This is what the form the volunteers are filling out looks like. Submitting
+      it won't work because you're already organizing this event. :D"
+     ],
      [new_event_email_path(@event),
       'fa fa-envelope',
       'Email Attendees',

--- a/app/views/rsvps/_form.html.erb
+++ b/app/views/rsvps/_form.html.erb
@@ -29,7 +29,7 @@
           Our experience is that people tend to underestimate their skills, so don't be
           shy about picking a higher class level if the description fits!
         </p>
-        <%= render partial: 'class_levels', locals: {
+        <%= render partial: 'rsvps/class_levels', locals: {
           f: f,
           levels: (@rsvp.event.course || Course::RAILS).levels,
           show_no_preference: false
@@ -81,7 +81,7 @@
         <p class="question">Do you have a class level preference?</p>
         <p class="details">(We'll try to get you into that class level, but no promises.)</p>
         <div class="field">
-          <%= render partial: 'class_levels', locals: {
+          <%= render partial: 'rsvps/class_levels', locals: {
             f: f,
             levels: (@rsvp.event.course || Course::RAILS).levels,
             show_no_preference: true
@@ -119,7 +119,7 @@
 
     <div class="field">
       <p class="question">The food's on us. Let us know if you have any dietary restrictions.</p>
-      <%= render partial: 'dietary_restrictions', locals: {f: f} %>
+      <%= render partial: 'rsvps/dietary_restrictions', locals: {f: f} %>
     </div>
 
     <div class="field question">

--- a/app/views/rsvps/new.html.erb
+++ b/app/views/rsvps/new.html.erb
@@ -5,7 +5,7 @@
 
   <h3>AWESOME - you're almost signed up!</h3>
 
-  <%= render 'form' %>
+  <%= render 'rsvps/form' %>
 
   <%= render 'shared/actions', links: [
     ['Back', events_path]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,7 +47,9 @@ Bridgetroll::Application.routes.draw do
     controller "events/organizer_tools" do
       get "send_survey_email"
       get "organize_sections"
-      get 'diets'
+      get "diets"
+      get "student_rsvp_preview"
+      get "volunteer_rsvp_preview"
     end
 
     collection do

--- a/spec/controllers/events/organizer_tools_controller_spec.rb
+++ b/spec/controllers/events/organizer_tools_controller_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
 
 describe Events::OrganizerToolsController do
+  let(:event) { FactoryGirl.create(:event) }
+  let(:admin) { create(:admin) }
+
   describe "GET #index" do
-    let(:event) { FactoryGirl.create(:event) }
 
     def make_request
       get :index, event_id: event.id
@@ -11,7 +13,7 @@ describe Events::OrganizerToolsController do
     it_behaves_like "an event action that requires an organizer"
 
     it "always allows admins, even if they aren't organizers of the event" do
-      sign_in(create(:admin))
+      sign_in(admin)
       make_request
       expect(response).to be_success
     end
@@ -51,6 +53,66 @@ describe Events::OrganizerToolsController do
           make_request
           expect(response).to redirect_to(events_path)
         end
+      end
+    end
+  end
+
+  describe "GET #student_rsvp_preview" do
+    let(:event) { FactoryGirl.create(:event) }
+
+    def make_request
+      get :student_rsvp_preview, event_id: event.id
+    end
+
+    it_behaves_like "an event action that requires an organizer"
+
+    it "always allows admins, even if they aren't organizers of the event" do
+      sign_in(admin)
+      make_request
+      expect(response).to be_success
+    end
+
+    context "logged in as the organizer" do
+      before do
+        user = create(:user)
+        event.organizers << user
+        sign_in user
+      end
+
+      it "shows you the student RSVP for that event" do
+        make_request
+        expect(response).to render_template(:new)
+        expect(assigns(:rsvp)).to be_a_new(Rsvp)
+      end
+    end
+  end
+
+  describe "GET #volunteer_rsvp_preview" do
+    let(:event) { FactoryGirl.create(:event) }
+
+    def make_request
+      get :volunteer_rsvp_preview, event_id: event.id
+    end
+
+    it_behaves_like "an event action that requires an organizer"
+
+    it "always allows admins, even if they aren't organizers of the event" do
+      sign_in(admin)
+      make_request
+      expect(response).to be_success
+    end
+
+    context "logged in as the organizer" do
+      before do
+        user = create(:user)
+        event.organizers << user
+        sign_in user
+      end
+
+      it "shows you the volunteer RSVP for that event" do
+        get :volunteer_rsvp_preview, event_id: event.id
+        expect(response).to render_template(:new)
+        expect(assigns(:rsvp)).to be_a_new(Rsvp)
       end
     end
   end

--- a/spec/features/event_organizer_dashboard_request_spec.rb
+++ b/spec/features/event_organizer_dashboard_request_spec.rb
@@ -19,6 +19,18 @@ describe "the organizer dashboard" do
     page.should have_content("Organizer Assignment")
   end
 
+  it "lets the user preview the student RSVP page" do
+    visit event_organizer_tools_path(@event)
+    click_link "Preview Student RSVP Form"
+    page.should have_content("Operating System")
+  end
+
+  it "lets the user preview the student RSVP page" do
+    visit event_organizer_tools_path(@event)
+    click_link "Preview Volunteer RSVP Form"
+    page.should have_content("Volunteer Preferences")
+  end
+
   it "lets the user assign students and volunteers to sections" do
     visit event_organizer_tools_path(@event)
     click_link "Arrange Class Sections"


### PR DESCRIPTION
- If the person looking at the organizer console hasn't RSVP'd (so, like, an admin), submitting this form will make a new RSVP. :frowning: 
- Organizers already have an RSVP, so they'll just see a "user has been taken" error :neutral_face: 

The question is ... how messed up will things get if admins start randomly RSVPing to things, thinking they are in some kind of non-existent preview mode? Is there a lazy thing I could do? (Not show the buttons to admins?)
