### PR TITLE
changes a few little things so that bootstrap 'form-control' behaves corrrectly

### DIFF
--- a/app/assets/stylesheets/events/_email.css.scss
+++ b/app/assets/stylesheets/events/_email.css.scss
@@ -4,7 +4,6 @@
   }
 
   textarea {
-    width: 600px;
     height: 275px;
   }
 
@@ -14,7 +13,7 @@
   }
 
   input[type=text] {
-    width: 600px;
+    margin-bottom: 20px;
   }
 
   input[type=radio], input[type=checkbox] {

--- a/app/views/events/emails/new.html.erb
+++ b/app/views/events/emails/new.html.erb
@@ -56,15 +56,14 @@
       .</span> <span class='recipients-popover'>[Who?]</span>
     </div>
 
-    <%= label_tag do %>
-      <div>Subject</div>
-      <%= f.text_field(:subject, placeholder: 'A message from your RailsBridge organizer', class: 'form-control') %>
-    <% end %>
-
-    <%= label_tag do %>
-      <div>Message Body</div>
-      <%= f.text_area(:body, placeholder: "Here's some important information about the upcoming workshop...", class: 'form-control') %>
-    <% end %>
+    <div class="row">
+      <div class="col-md-8">
+        <%= f.label :subject, "Subject" %>
+        <%= f.text_field :subject, placeholder: 'A message from your RailsBridge organizer', class: "form-control" %>
+        <%= f.label :body, "Message Body" %>
+        <%= f.text_area :body, placeholder: "Here's some important information about the upcoming workshop...", class: 'form-control' %>
+      </div>
+    </div>
 
     <div style="margin-top: 10px;"><%= f.submit 'Send Mail', class: 'btn' %></div>
   <% end %>


### PR DESCRIPTION
I was forced to send out a BridgeTroll email to volunteers the other night on my phone, and the form was being really annoying. I checked on my computer later and the form was definitely not being responsive. I'm not sure why, but the "label_tag" was causing some problems. Also, the form elements had explicit widths in the style. I removed those and rearranged the form elements a bit. Works great on my end now.
