### PR TITLE
Notify event organizers thier event is awaiting approval

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -54,6 +54,7 @@ class EventsController < ApplicationController
         @event.update_attribute(:spam, true)
       else
         EventMailer.unpublished_event(@event).deliver_now
+        EventMailer.event_pending_approval(@event).deliver_now
       end
 
       if @event.published

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -25,6 +25,16 @@ class EventMailer < BaseMailer
     )
   end
 
+  def event_pending_approval(event)
+    @event = event
+
+    set_recipients(event.organizers.map(&:email))
+
+    mail(
+      subject: "Your Bridge Troll event is pending approval: '#{@event.title}'"
+    )
+  end
+
   def new_event(event)
     @event = event
     return unless @event.location

--- a/app/views/event_mailer/event_pending_approval.html.erb
+++ b/app/views/event_mailer/event_pending_approval.html.erb
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="text/html; charset=UTF-8" http-equiv="Content-Type"/>
+</head>
+<body>
+
+<p>Dear <%= @event.organizers.first.first_name %>,</p>
+
+<p>
+  We're so excited that you're organizing <%= @event.title %>! For spam-prevention and quality assurance, your event needs to be approved by a Bridge Troll admin before it is announced to your chapter and visible on the site.
+</p>
+<p>
+  Admins are looking particularly to make sure that your event specifically states what underrepresented populations it is reaching out to, and that the workshop is free. (And they might tell you about any typos they find, or things that don't make sense, if they find either.)
+</p>
+<p>
+  If you have any questions, or if it's been a day or two and you haven't heard anyone, please email bridgetroll@railsbridge.org.
+</p>
+<p>Sincerely,</p>
+<p>The Troll</p>
+
+</body>
+</html>

--- a/app/views/event_mailer/event_pending_approval.txt.erb
+++ b/app/views/event_mailer/event_pending_approval.txt.erb
@@ -1,0 +1,10 @@
+Dear <%= @event.organizers.first.first_name %>,
+
+We're so excited that you're organizing <%= @event.title %>! For spam-prevention and quality assurance, your event needs to be approved by a Bridge Troll admin before it is announced to your chapter and visible on the site.
+
+Admins are looking particularly to make sure that your event specifically states what underrepresented populations it is reaching out to, and that the workshop is free. (And they might tell you about any typos they find, or things that don't make sense, if they find either.)
+
+If you have any questions, or if it's been a day or two and you haven't heard anyone, please email bridgetroll@railsbridge.org.
+
+Sincerely,
+The Troll


### PR DESCRIPTION
I feel iffy about the controller spec. It was tough to isolate testing the email to admins from the one to organizers. Open to input there or anywhere.

:left_shark: