### PR TITLE
Event show style tweaks

### DIFF
--- a/app/assets/stylesheets/_fonts.scss
+++ b/app/assets/stylesheets/_fonts.scss
@@ -48,6 +48,5 @@
   font_url('Amble-Bold-webfont.svg#AmbleBold') format('svg');
   font-weight: normal;
   font-style: normal;
-
 }
 

--- a/app/assets/stylesheets/events/_show.scss
+++ b/app/assets/stylesheets/events/_show.scss
@@ -47,6 +47,16 @@
   h2 {
     margin-top: 20px;
   }
+
+  h3 {
+    margin: 20px 0 5px 0;
+    font-family: 'AmbleRegular', sans-serif;
+  }
+
+  ul {
+    margin: 0 0 10px 25px;
+    list-style-type: disc;
+  }
 }
 
 .critical-details {
@@ -54,7 +64,7 @@
   font-size: 18px;
 
   a {
-    text-decoration: none ;
+    text-decoration: none;
   }
 
   div {

--- a/app/assets/stylesheets/utilities.scss
+++ b/app/assets/stylesheets/utilities.scss
@@ -1,3 +1,3 @@
-.mb-20 {
+.mb20 {
   margin-bottom: 20px;
 }

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -61,7 +61,7 @@ module EventsHelper
     simple_format(
       Sanitize.clean(string, Sanitize::Config::RELAXED),
       :sanitize => false
-    ).gsub(%r{(</h\d>)\s*<br\s*/>}, '\1').html_safe # remove unsightly </h2>\n<br/> combos
+    ).gsub(%r{(</h\d>|</li>|<ul>|<li>)\s*<br\s*/>}, '\1').html_safe # remove unsightly </h2>\n<br/> combos
   end
 
   def formatted_event_date_range(event)

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -10,7 +10,7 @@
 <% end %>
 
 <% if @chapter.has_leader?(current_user) %>
-  <%= link_to 'Edit Chapter Leaders', chapter_chapter_leaderships_path(@chapter), class: "btn mb-20" %>
+  <%= link_to 'Edit Chapter Leaders', chapter_chapter_leaderships_path(@chapter), class: "btn mb20" %>
 
   <h2>Organizers</h2>
   <table class="datatable-sorted table table-striped table-bordered table-condensed responsive-table">

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -146,7 +146,8 @@
     <ul class="margined">
       <li><pre><%= "<img src='http://example.com/sponsor/logo'>" %></pre></li>
       <li><pre><%= "<a href='http://bridgetroll.org'>Link Text</a>" %></pre></li>
-      <li><pre><%= "<h3>Littler Header</h3>" %></pre></li>
+      <li><pre><%= "<h3>Littler Header</h3>\nMore text below, no blank line needed after headers" %></pre></li>
+      <li><pre><%= "<ul>\n<li>List Item One</li>\n<li>List Item Two</li>\n</ul>" %></pre></li>
     </ul>
     <p>But you don't have to put paragraph tags around everything; blank lines will do just fine.</p>
     <%= f.input :details, as: :text, input_html: {rows: 14} %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -99,7 +99,9 @@
     </div>
     <h3><%= pluralize(@event.checked_in_volunteer_rsvps.count, "volunteer") %>!</h3>
     <% if @event.volunteer_rsvps.none? %>
-      No volunteers are currently signed up for this event.
+      <div class="mb20">
+        No volunteers are currently signed up for this event.
+      </div>
     <% else %>
       <ul class="attendees">
         <% @event.ordered_volunteer_rsvps.each do |rsvp| %>
@@ -110,7 +112,9 @@
     <% if @event.allow_student_rsvp? %>
       <h3><%= pluralize(@event.checked_in_student_rsvps.count, "student") %>!</h3>
       <% if @event.student_rsvps.none? %>
-        No students are currently signed up for this event.
+        <div class="mb20">
+          No students are currently signed up for this event.
+        </div>
       <% else %>
         <ul class="attendees">
           <% @event.ordered_student_rsvps.each do |rsvp| %>


### PR DESCRIPTION
* Add some margin to the "no one has signed up yet" text
* Update `h3` and `ul` styling in event details

To get the `ul`s not to look terrible, I had to add them to the regex in the `simple_format_with_html` method. This might not have been the best approach, so feedback there welcome.