### PR TITLE
Fix GitHub capitalization

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -125,7 +125,7 @@ Bridge Troll uses [Omniauth](https://github.com/intridea/omniauth) to allow exte
 
 * Twitter through [omniauth-twitter](https://github.com/arunagw/omniauth-twitter) - [set up a consumer here](https://apps.twitter.com/)
 * Facebook through [omniauth-facebook](https://github.com/mkdynamic/omniauth-facebook) - [set up a consumer here](https://developers.facebook.com/apps/)
-* Github through [omniauth-github](https://github.com/intridea/omniauth-github) - [set up a consumer here](https://github.com/settings/applications)
+* GitHub through [omniauth-github](https://github.com/intridea/omniauth-github) - [set up a consumer here](https://github.com/settings/applications)
 * Meetup through [omniauth-meetup](https://github.com/tapster/omniauth-meetup) - [set up a consumer here](http://www.meetup.com/meetup_api/oauth_consumers/)
 
 To set up external authentication, create an oauth consumer on the site you want to authenticate with, then add [PROVIDER]_OAUTH_KEY and [PROVIDER]_OAUTH_SECRET value to the app environment.

--- a/app/services/omniauth_providers.rb
+++ b/app/services/omniauth_providers.rb
@@ -13,7 +13,7 @@ module OmniauthProviders
       },
       {
         key: :github,
-        name: 'Github',
+        name: 'GitHub',
         icon: 'fa-github-square'
       },
       {

--- a/app/views/devise/registrations/_form.html.erb
+++ b/app/views/devise/registrations/_form.html.erb
@@ -58,7 +58,7 @@
 
           <%= ff.input :bio, input_html: {rows: 3} %>
 
-          <%= ff.input :github_username %>
+          <%= ff.input :github_username, label: "GitHub username" %>
         <% end %>
       <% end %>
 

--- a/spec/features/profiles_spec.rb
+++ b/spec/features/profiles_spec.rb
@@ -62,7 +62,7 @@ describe "Profile" do
 
     fill_in "Other Skills", with: "Speaking Spanish"
     fill_in "Bio", with: "This is my bio..."
-    fill_in "Github username", with: "sally33"
+    fill_in "GitHub username", with: "sally33"
 
     click_button "Update"
 


### PR DESCRIPTION
I was updating my profile after https://www.bridgetroll.org/events/134 , and noticed that GitHub was incorrectly capitalized like Github.