### PR TITLE
Organizers can change RSVP status

### DIFF
--- a/app/controllers/events/attendees_controller.rb
+++ b/app/controllers/events/attendees_controller.rb
@@ -2,7 +2,7 @@ class Events::AttendeesController < ApplicationController
   before_filter :authenticate_user!, :validate_organizer!, :find_event
 
   def index
-    @rsvps = @event.attendee_rsvps
+    @rsvps = @event.rsvps.where(role_id: Role.attendee_role_ids)
     respond_to do |format|
       format.csv { render csv: @rsvps }
       format.html { }

--- a/app/views/events/attendees/index.html.erb
+++ b/app/views/events/attendees/index.html.erb
@@ -32,6 +32,7 @@
         <th class='attendee-gender'>Gender</th>
         <th class='attendee-dietary-info'>Plus-One Host</th>
         <th class='attendee-waitlisted'>Waitlisted</th>
+        <th>Remove RSVP</th>
       </tr>
     </thead>
     <tbody>
@@ -48,6 +49,10 @@
           <td data-label="Gender:"><%= rsvp.user.gender %></td>
           <%= content_tag_maybe_hidden(:td, rsvp.plus_one_host, 'data-label' => 'Plus-one host:') %>
           <td data-label="Waitlisted?:"><%= if rsvp.waitlist_position then "yes" else "no" end %></td>
+
+
+          <td><%= link_to 'Destroy', [rsvp.event, rsvp], method: :delete, data: { confirm: 'Are you sure?' } %></td>
+
           </tr>
         <% end %>
       </tbody>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -86,6 +86,10 @@ FactoryGirl.define do
       class_level 0
     end
 
+    factory :organizer_rsvp do
+      role Role.find_by_title 'Organizer'
+    end
+    
   end
 
   factory :dietary_restriction do


### PR DESCRIPTION
changes in this commit:
- the organizer's view of attendees now includes attendees on the waitlist (this is expected based on the descriptions in the UI, and is necessary if we're moving students off the waitlist manually)
- the organizer's view of attendees includes a link to completely delete an RSVP
- the organizer's view of attendees includes a button to either put the attendee on a waitlist or remove them from one, depending on their current status