### PR TITLE
adds a simple api to see how many events a user has attended

### DIFF
--- a/app/controllers/users/events_controller.rb
+++ b/app/controllers/users/events_controller.rb
@@ -1,0 +1,11 @@
+module Users
+  class EventsController < ApplicationController
+    # Provides a simple, public, mini-api to allow third parties to check to 
+    # see if a user has attended any classes
+    def index
+      @user = User.find(params[:user_id])
+      @event_count = @user.rsvps.where('checkins_count > 0').count
+      render json: { event_count: @event_count }, status: 200
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Bridgetroll::Application.routes.draw do
 
   resources :users, only: [:index] do
     resource :profile, only: [:show]
+    resources :events, only: [:index], controller: 'users/events'
   end
   resources :meetup_users, only: [:show]
 

--- a/spec/controllers/users/events_controller_spec.rb
+++ b/spec/controllers/users/events_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe Users::EventsController do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:event) { FactoryGirl.create(:event) }
+  let!(:rsvp) { FactoryGirl.create(:rsvp, user: user, event: event,
+                                   checkins_count: 1) }
+
+  describe "#index" do
+    it 'should respond successfully with json' do
+      get :index, user_id: user.id
+      response.content_type.should == 'application/json'
+      response.should be_success
+    end
+
+    it 'should respond with the correct count' do
+      get :index, user_id: user.id
+      expected_response = {event_count: 1}.to_json
+      response.body.should == expected_response
+    end
+  end
+end


### PR DESCRIPTION
Hi all, this is a pull request to add a very simple json api to find out how many events a user has attended. 

We are proposing this change because we would like to add a badge on the www.railsschool.org site if one of our users has attended a RailsBridge class (many of us teach or volunteer with RailsBridge, and many of our students are also involved).

I did not create a separate API namespace because this change is so simple. Also, note this controller is not protected by auth, but we don't think that's a significant issue in this case and it greatly simplifies things. Comments or feedback welcome, we're happy to make whatever changes are necessary for this to work. Thanks!

EDIT - 2nd commit to clean up some style issues