### PR TITLE
Fix chapter filter criteria saving to local storage

### DIFF
--- a/app/assets/javascripts/events.js.coffee
+++ b/app/assets/javascripts/events.js.coffee
@@ -60,4 +60,6 @@ jQuery ->
     setUpDatePicker($dateField)
     setUpExclusiveCheckboxes($field)
 
-  new EventsFilterView(el: $('.chapter-select'))
+  $chapterSelect = $('.chapter-select')
+  if $chapterSelect.length > 0
+    new EventsFilterView(el: $chapterSelect)


### PR DESCRIPTION
The filter criteria that was being saved to local storage was also being erased whenever I was on a page that didn't include the filter select box since it would still try to restore the previously saved selection.

In the process of restoring it would check to make sure that the previous selection was still a valid option. While doing this check it would find that it was not in the array of options and removed it from local storage. It wasn't in the array since there was no select box to have any options in it making the array empty.

To fix this, I just changed it to only load the Backbone view when the chapter filter select box is in the DOM.