### PR TITLE
Update attendees.csv to match attendees table.

### DIFF
--- a/app/views/events/attendees/index.csv.erb
+++ b/app/views/events/attendees/index.csv.erb
@@ -1,6 +1,11 @@
-<% headers = ['Name', 'Role', 'Gender'] -%>
-<%= CSV.generate_line headers %>
+<% headers = ['Name', 'Attending As', 'Dietary Info', 'Childcare Info',
+              'Job Details', 'Gender', 'Plus-One Host', 'Waitlisted',
+              'Waitlist Position'] -%>
+<%= CSV.generate_line(headers).strip %>
 <% @rsvps.each do |rsvp| -%>
-  <% row = [rsvp.user.full_name, rsvp.role.name] -%>
-  <%= CSV.generate_line row %>
+  <% waitlisted = rsvp.waitlisted? ? 'yes' : 'no' %>
+  <% row = [rsvp.user.full_name, rsvp.role.title, rsvp.dietary_info,
+            rsvp.childcare_info, rsvp.job_details, rsvp.user.gender,
+            rsvp.plus_one_host, waitlisted, rsvp.waitlist_position] %>
+  <%= CSV.generate_line(row).strip %>
 <% end -%>

--- a/spec/controllers/events/attendees_controller_spec.rb
+++ b/spec/controllers/events/attendees_controller_spec.rb
@@ -1,16 +1,25 @@
 require 'rails_helper'
 
 describe Events::AttendeesController do
-  describe "#update" do
-    before do
-      @event = create(:event)
-      @organizer = create(:user)
-      @event.organizers << @organizer
+  before do
+    @event = create(:event)
+    @organizer = create(:user)
+    @event.organizers << @organizer
 
-      @rsvp = create(:rsvp, event: @event)
+    @rsvp = create(:rsvp, event: @event)
 
-      sign_in @organizer
+    sign_in @organizer
+  end
+
+  describe '#index' do
+    it 'responds to csv' do
+      get :index, event_id: @event.id, format: :csv
+      expect(response).to have_http_status(:success)
+      expect(response.content_type).to eq('text/csv')
     end
+  end
+
+  describe "#update" do
 
     let(:do_request) do
       put :update, event_id: @event.id, id: @rsvp.id, attendee: {


### PR DESCRIPTION
Hi everyone,

I'm an organizer for Railsbridge Oakland. I was looking at the https://www.bridgetroll.org/events/:id/attendees page and found that the export to CSV was missing the information available there. This PR tries to reconcile the two tables.

I also noticed that `CSV.generate_line(...)` is creating new lines so I changed it to `CSV.generate_line(...).strip`.

I've also included a simple test that ensures CSV is exportable. It makes no attempt to test the structure of the CSV.

Hopefully, this is a PR that the maintainers of bridge troll may find useful. If there's anything I can do to improve it, let me know.