### PR TITLE
moved 'new event' button on external events page

### DIFF
--- a/app/views/external_events/index.html.erb
+++ b/app/views/external_events/index.html.erb
@@ -1,5 +1,9 @@
 <%= content_for(:header_text, 'Listing external events') %>
 
+<div class="mb20">
+  <%= render 'shared/actions', links: [['New External Event', new_external_event_path]] %>
+</div>
+
 <table class="table table-striped table-bordered table-condensed external-events">
   <tr>
     <th>Name</th>
@@ -38,7 +42,3 @@
     </tr>
   <% end %>
 </table>
-
-<%= render 'shared/actions', links: [
-  ['New External Event', new_external_event_path]
-] %>


### PR DESCRIPTION
Edited "External Events" page to make "New Events" button at top of page. Paired with @lilliealbert 

Test plan: Go to "external_events". Button "New External Event" should be at the top of the table of external events.

Reviewer: @lilliealbert 