### PR TITLE
WIP - Organizer may close RSVP for an event.

### DIFF
--- a/app/controllers/events/organizer_tools_controller.rb
+++ b/app/controllers/events/organizer_tools_controller.rb
@@ -40,4 +40,10 @@ class Events::OrganizerToolsController < ApplicationController
     @rsvp_preview_mode = true
     render "rsvps/new"
   end
+
+  def close_rsvps
+    @event.close_rsvps
+    flash[:notice] = "RSVPs closed successfully."
+    redirect_to event_organizer_tools_path(@event)
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -84,6 +84,15 @@ class Event < ActiveRecord::Base
     "http://#{meetup_group_url}/events/#{meetup_event_id}/"
   end
 
+  def close_rsvps
+    self.open = false
+    self.save
+  end
+
+  def closed?
+    !open?
+  end
+
   def students_at_limit?
     if student_rsvp_limit
       student_rsvps_count >= student_rsvp_limit

--- a/app/views/events/_organizer_preworkshop_buttons.html.erb
+++ b/app/views/events/_organizer_preworkshop_buttons.html.erb
@@ -37,6 +37,11 @@
       'Workshop Cookbook',
       "Organizing events is a lot of work! RailsBridge has put together a detailed
         guide to running a workshop (easily used for other events, too)."
+     ],
+     [event_close_rsvps_path(@event),
+      'fa fa-pencil',
+      'Close RSVPs',
+      "Prevent RSVPs from volunteers and students. This will also close the waitlist. To close RSVPs just for students, change the number of attendees by editing the event."
      ]
    ].each do |button| %>
   <%= render 'shared/organizer_action',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Bridgetroll::Application.routes.draw do
       get "organize_sections"
       get "diets"
       get "rsvp_preview"
+      get "close_rsvps"
     end
 
     collection do

--- a/db/migrate/20150719210256_add_open_to_events.rb
+++ b/db/migrate/20150719210256_add_open_to_events.rb
@@ -1,0 +1,5 @@
+class AddOpenToEvents < ActiveRecord::Migration
+  def change
+    add_column :events, :open, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150615233700) do
+ActiveRecord::Schema.define(version: 20150719210256) do
 
   create_table "authentications", force: :cascade do |t|
     t.integer  "user_id"
@@ -113,6 +113,7 @@ ActiveRecord::Schema.define(version: 20150615233700) do
     t.boolean  "draft_saved"
     t.integer  "volunteer_rsvp_limit"
     t.integer  "volunteer_waitlist_rsvps_count", default: 0
+    t.boolean  "open",                           default: true
   end
 
   create_table "external_events", force: :cascade do |t|

--- a/spec/features/organizer_closes_rsvps_spec.rb
+++ b/spec/features/organizer_closes_rsvps_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+describe "organizer closes RSVPs" do
+
+	context "when RSVPs are open" do
+
+		it "allows volunteers to RSVP" do
+			create(:event)
+			
+			visit root_path
+
+			within(".upcoming-events") do
+				expect(page).to have_link('Volunteer')
+			end
+		end
+
+		it "allows students to RSVP"
+
+		it "allows the organizers to close RSVPs" do
+			event = create(:event)
+			organizer = create(:user)
+			event.organizers << organizer
+			sign_in_as(organizer)
+
+			visit event_organizer_tools_path(event)
+			click_link("Close RSVPs")
+
+			within(".alert-success") do
+				expect(page).to have_content("RSVPs closed successfully.")
+			end
+			expect(event.reload).to be_closed
+		end
+
+	end
+
+	context "when RSVPs are closed" do
+		it "prevents volunteers from RSVPing"
+		it "pevents students from RSVPing"
+		it "allows organizers to reopen RSVPs"
+	end
+
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -314,6 +314,14 @@ describe Event do
     end
   end
 
+  describe "#close_rsvps" do
+    it "closes the event" do
+      event = create(:event, open: true)
+      event.close_rsvps
+      expect(event.reload).to be_closed
+    end
+  end
+
   describe "#students_at_limit?" do
     context "when the event has a student limit" do
       let(:event) { create(:event, student_rsvp_limit: 2) }


### PR DESCRIPTION
- [x] There should be a button on the organizer console that lets organizers close RSVPs
- [ ] Console button should also close the waitlist
- [ ] Instead of the RSVP buttons, show some text that says "RSVP are closed!"
- [ ] The wait list should still function as it does now (moving people off of the waitlist as spots become available)
- [ ] Remove volunteer/register buttons when rsvps are closed.