### PR TITLE
New required text field: Target audience

### DIFF
--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -40,6 +40,15 @@
     <%= collection_select :event, :course_id, Course.all, :id, :title, {}, {class: 'form-control'} %>
   </div>
 
+  <div class="field workshop-only">
+    <%= f.input :target_audience, label: 'What population is this workshop reaching out to?' %>
+    <p>
+      <em>
+        All workshops must reach out to one or more underrepresented population in text, such as women, people of color, or transgender people.
+      </em>
+    </p>
+  </div>
+
   <div class="field">
     <%= f.input :time_zone, priority: ActiveSupport::TimeZone.us_zones, include_blank: 'Select Time Zone' %>
   </div>

--- a/db/migrate/20150719210732_add_target_audience_to_events.rb
+++ b/db/migrate/20150719210732_add_target_audience_to_events.rb
@@ -1,0 +1,5 @@
+class AddTargetAudienceToEvents < ActiveRecord::Migration
+  def change
+    add_column :events, :target_audience, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150615233700) do
+ActiveRecord::Schema.define(version: 20150719210732) do
 
   create_table "authentications", force: :cascade do |t|
     t.integer  "user_id"
@@ -113,6 +113,7 @@ ActiveRecord::Schema.define(version: 20150615233700) do
     t.boolean  "draft_saved"
     t.integer  "volunteer_rsvp_limit"
     t.integer  "volunteer_waitlist_rsvps_count", default: 0
+    t.string   "target_audience"
   end
 
   create_table "external_events", force: :cascade do |t|

--- a/db/seeds/seed_event.rb
+++ b/db/seeds/seed_event.rb
@@ -82,6 +82,7 @@ module Seeder
       course_id: Course::RAILS.id,
       location: location,
       published: true,
+      target_audience: 'women',
       details: <<-DETAILS.strip_heredoc
         <h2>Workshop Description</h2>
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -223,6 +223,7 @@ describe EventsController do
           {
             "event" => {
               "title" => "Party Zone",
+              "target_audience" => "yaya",
               "time_zone" => "Alaska",
               "student_rsvp_limit" => 100,
               "event_sessions_attributes" => {

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -36,6 +36,7 @@ FactoryGirl.define do
     course_id Course::RAILS.id
     volunteer_details "I am some details for volunteers."
     student_details "I am some details for students."
+    target_audience "default target audience"
 
     factory :event do
       before(:create) do |event, evaluator|

--- a/spec/features/event_listing_request_spec.rb
+++ b/spec/features/event_listing_request_spec.rb
@@ -68,6 +68,7 @@ describe "the event listing page" do
       it "can create a new course" do
         fill_in_good_event_details
         
+        fill_in "event_target_audience", :with => "women"
         fill_in "event_details", :with => "This is a note in the detail text box\n With a new line!<script>alert('hi')</script> and a (missing) javascript injection, as well as an unclosed <h1> tag"
         check("coc")
         click_button submit_for_approval_button
@@ -91,6 +92,7 @@ describe "the event listing page" do
 
       it "can create a non-teaching event" do
         fill_in "Title", with: "Volunteer Work Day"
+        fill_in "event_target_audience", :with => "women"
         choose "Just Volunteers"
 
         within ".event-sessions" do
@@ -117,6 +119,7 @@ describe "the event listing page" do
         click_link "Organize Event"
 
         fill_in "Title", with: "March Event"
+        fill_in "event_target_audience", :with => "women"
         select "Front End", :from => "event_course_id"
         fill_in "Student RSVP limit", with: 100
 

--- a/spec/features/new_event_request_spec.rb
+++ b/spec/features/new_event_request_spec.rb
@@ -11,6 +11,11 @@ describe "New Event" do
     visit "/events/new"
   end
 
+  it "should have 'Target Audience'" do
+    label = 'What population is this workshop reaching out to?'
+    page.should have_field(label)
+  end
+
   it "should pre-fill the event details textarea" do
     page.should have_field('Details')
     page.field_labeled('Details')[:value].should =~ /Workshop Description/
@@ -43,6 +48,7 @@ describe "New Event" do
 
   it 'allows organizers to specify a whitelist of allowed OSes', js: true do
     fill_in_good_event_details
+    fill_in 'event_target_audience', :with => "women"
     
     check('Do you want to restrict the operating systems students should use?')
     uncheck('Linux - Other')
@@ -85,6 +91,7 @@ describe "New Event" do
 
     it 'allows a draft to be saved' do
       fill_in_good_event_details
+      fill_in 'event_target_audience', :with => "women"
       page.should have_button 'Save Draft'
       click_on 'Save Draft'
 


### PR DESCRIPTION
Added a required text field that asks workshop creators to specify their "target audience." The field is not required for non-workshop events. I had to go through and change a few different tests and files to change how they created events now that there is a new required event.

Im one of the Juniors at Carbon Five working on a few stories Lillie helped us put together. The specific story I worked on is here: https://www.pivotaltracker.com/story/show/99063524