### PR TITLE
Reminder email with direct cancel

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -425,4 +425,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.10.4
+   1.10.6

--- a/app/controllers/rsvps_controller.rb
+++ b/app/controllers/rsvps_controller.rb
@@ -1,10 +1,15 @@
 class RsvpsController < ApplicationController
-  before_filter :authenticate_user!
+  before_filter :authenticate_user!, except: [:quick_destroy_confirm, :destroy]
   before_filter :assign_event
-  before_filter :load_rsvp, except: [:volunteer, :learn, :create]
+  before_filter :load_rsvp, only: [:edit, :update]
   before_filter :redirect_if_rsvp_exists, only: [:volunteer, :learn]
   before_filter :redirect_if_event_in_past
 
+  def quick_destroy_confirm
+    @rsvp = Rsvp.where(event_id: params[:event_id], id: params[:rsvp_id]).take
+    @token = params[:token]
+    render 'rsvps/quick_destroy_confirm'
+  end
 
   def volunteer
     @rsvp = @event.rsvps.build(user: current_user)
@@ -20,6 +25,7 @@ class RsvpsController < ApplicationController
 
   def create
     @rsvp = Rsvp.new(rsvp_params)
+    generate_token
     @rsvp.event = @event
     @rsvp.user = current_user
     if Role.attendee_role_ids.include?(params[:rsvp][:role_id].to_i)
@@ -70,12 +76,18 @@ class RsvpsController < ApplicationController
   end
 
   def destroy
+    @rsvp = Rsvp.find_by(token: params[:token]) if params[:token]
+
+    if @rsvp.nil?
+      authenticate_user! && load_rsvp
+    end
+
     Rsvp.transaction do
       @rsvp.destroy
       WaitlistManager.new(@event.reload).reorder_waitlist!
     end
 
-    if @event.organizer?(current_user)
+    if current_user && @event.organizer?(current_user)
       redirect_to event_attendees_path(@event), notice: "#{@rsvp.user.first_name} is no longer signed up for #{@event.title}"
     else
       redirect_to events_path, notice: "You are now no longer signed up for #{@event.title}"
@@ -135,5 +147,13 @@ class RsvpsController < ApplicationController
 
   def assign_event
     @event = Event.find_by_id(params[:event_id])
+    if @event.nil?
+      redirect_to events_path, notice: 'You are not signed up for this event'
+    end
+  end
+
+  def generate_token
+    token = SecureRandom.uuid.gsub(/\-/, '')
+    @rsvp.update(token: token)
   end
 end

--- a/app/views/rsvp_mailer/_event_details.html.erb
+++ b/app/views/rsvp_mailer/_event_details.html.erb
@@ -23,7 +23,7 @@ You'll be <%= verb(@rsvp.role) %> <%= pluralize(@rsvp.rsvp_sessions.count, 'sess
 
 <p>If any of your details (childcare, class preference, food needs) change, you can <%= link_to 'update your RSVP here', edit_event_rsvp_url(@rsvp.event, @rsvp.id) %>.</p>
 
-<p>If your plans change and you can't make it to the workshop, be sure to <%= link_to "cancel your RSVP on the event page", event_url(@rsvp.event) %><% if @rsvp.role_student? %> so that someone from the waitlist can have your spot<% end %>.</p>
+<p>If your plans change and you can't make it to the workshop, be sure to <%= link_to "cancel your RSVP on the event page", event_rsvp_quick_destroy_confirm_url(@rsvp.event, @rsvp, token: @rsvp.token) %><% if @rsvp.role_student? %> so that someone from the waitlist can have your spot<% end %>.</p>
 
 <% if @rsvp.role_student? %>
   <%= simple_format_with_html(@rsvp.event.student_details) %>

--- a/app/views/rsvp_mailer/_event_details.txt.erb
+++ b/app/views/rsvp_mailer/_event_details.txt.erb
@@ -18,7 +18,7 @@ You're signed up to <%= verb(@rsvp.role) %> <%= pluralize(@rsvp.rsvp_sessions.co
 
 If any of your details (childcare, class preference, food needs) change, you can <%= link_to 'update your RSVP here', edit_event_rsvp_path(@rsvp.event, @rsvp.id) %>.
 
-If your plans change and you can't make it to the workshop, be sure to <%= link_to "cancel your RSVP on the event page", event_url(@rsvp.event) %><% if @rsvp.role_student? %> so that someone from the waitlist can have your spot<% end %>.
+If your plans change and you can't make it to the workshop, be sure to <%= link_to "cancel your RSVP on the event page", event_rsvp_quick_destroy_confirm_url(@rsvp.event, @rsvp, token: @rsvp.token) } %><% if @rsvp.role_student? %> so that someone from the waitlist can have your spot<% end %>.
 
 <% if @rsvp.role_student? %>
   <%= @rsvp.event.student_details %>

--- a/app/views/rsvps/quick_destroy_confirm.html.erb
+++ b/app/views/rsvps/quick_destroy_confirm.html.erb
@@ -1,0 +1,12 @@
+<h1>
+  Are you sure you want to cancel?
+</h1>
+
+<ul class="actions no-margin">
+  <li>
+    <%= link_to 'Yes', event_rsvp_path(@event, @rsvp, token: @token), class: 'btn btn-submit', method: :delete %>
+  </li>
+  <li>
+    <%= link_to 'No', root_path, class: 'btn' %>
+  </li>
+</ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,14 +31,16 @@ Bridgetroll::Application.routes.draw do
     end
 
     resources :rsvps, except: [:show, :index, :new] do
+      get :quick_destroy_confirm
+
       new do
         get :volunteer
         get :learn
       end
+
       resources :surveys, only: [:new, :create]
     end
-
-    resources :surveys, only: [:new, :index]
+ resources :surveys, only: [:new, :index]
 
     resources :event_sessions, only: [:index, :show, :destroy] do
       resources :checkins, only: [:index, :create, :destroy]

--- a/db/migrate/20150726194812_add_token_to_rsvp.rb
+++ b/db/migrate/20150726194812_add_token_to_rsvp.rb
@@ -1,0 +1,7 @@
+class AddTokenToRsvp < ActiveRecord::Migration
+  def change
+    add_column :rsvps, :token, :string
+
+    add_index :rsvps, :token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150719210732) do
+ActiveRecord::Schema.define(version: 20150726194812) do
 
   create_table "authentications", force: :cascade do |t|
     t.integer  "user_id"
@@ -206,8 +206,10 @@ ActiveRecord::Schema.define(version: 20150719210732) do
     t.integer  "section_id"
     t.boolean  "checkiner",                           default: false
     t.text     "plus_one_host"
+    t.string   "token"
   end
 
+  add_index "rsvps", ["token"], name: "index_rsvps_on_token", unique: true
   add_index "rsvps", ["user_id", "event_id", "user_type"], name: "index_rsvps_on_user_id_and_event_id_and_event_type", unique: true
 
   create_table "sections", force: :cascade do |t|


### PR DESCRIPTION
* User is now permitted to cancel RSVP's without authentication via link in email
* RSVP now has a cancelation token that is sent through the email
* Created a view that confirms whether the user wishes to cancel their RSVP event