### PR TITLE
Manual or automatic sending of event announcement emails

### DIFF
--- a/app/controllers/events/organizer_tools_controller.rb
+++ b/app/controllers/events/organizer_tools_controller.rb
@@ -52,4 +52,15 @@ class Events::OrganizerToolsController < ApplicationController
     flash[:notice] = "RSVPs reopened successfully."
     redirect_to event_organizer_tools_path(@event)
   end
+
+  def send_announcement_email
+    @event = Event.find(params[:event_id])
+    if @event.announcement_email_sent_at.nil? and @event.published?
+      EventMailer.new_event(@event).deliver_now
+      @event.update_attribute(:announcement_email_sent_at, DateTime.now)
+      redirect_to event_organizer_tools_path(@event), notice: "Your announcement email was sent!"
+    else
+      redirect_to event_organizer_tools_path(@event), alert: "You can't do that."
+    end
+  end
 end

--- a/app/controllers/events/unpublished_events_controller.rb
+++ b/app/controllers/events/unpublished_events_controller.rb
@@ -15,7 +15,10 @@ class Events::UnpublishedEventsController < ApplicationController
 
   def publish
     @event.update_attribute(:published, true)
-    EventMailer.new_event(@event).deliver_now if @event.email_on_approval
+    if @event.email_on_approval
+      EventMailer.new_event(@event).deliver_now 
+      @event.update_attribute(:announcement_email_sent_at, DateTime.now)
+    end
     redirect_to @event, notice: "This event has been published. Now everyone in the world can see it!"
   end
 

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -222,7 +222,13 @@
 
     <div class="field non-bolded">
       <%= f.label :email_on_approval do %>
-        <%= f.check_box :email_on_approval %> Send announcement email to chapter when the event is approved
+        <%= label_tag do %>
+          <%= f.radio_button :email_on_approval, true %> Send the announcement email when the event is approved
+        <% end %>
+        <%= label_tag do %>
+          <%= f.radio_button :email_on_approval, false %> Let me control when to send the announcement email
+          <i>(A button will show up on your organizer console when your event is approved)</i>
+        <% end %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/events/organizer_tools/index.html.erb
+++ b/app/views/events/organizer_tools/index.html.erb
@@ -7,6 +7,16 @@
   <div class="col-md-6">
     <h2>Tools for before the event</h2>
     <section class='organizer-dashboard-section'>
+      <% if @event.announcement_email_sent_at.nil? and @event.published? %>
+        <%= render partial: 'shared/organizer_action', locals: {
+          path: event_send_announcement_email_path(@event),
+          icon: 'fa fa-envelope',
+          text: 'Send Announcement Email',
+          tip: "Send an announcement email to members subscribed to your event's chapter.",
+          confirm: 'Are you sure?',
+          verb: :post
+        } %>
+      <% end %>
       <%= render partial: 'events/organizer_preworkshop_buttons' %>
     </section>
 

--- a/app/views/events/unpublished_events/_unpublished_event.html.erb
+++ b/app/views/events/unpublished_events/_unpublished_event.html.erb
@@ -20,7 +20,7 @@
                       data: {confirm: "Are you sure? This will email #{pluralize(@chapter_user_counts[event.location.chapter.id], 'member')} of #{event.location.chapter.name}"} %>
       <% else %>
         <%= button_to 'Publish', unpublished_event_publish_path(event), class: 'btn', method: :post,
-                      data: {confirm: "Are you sure? The event will start showing for all users, but no one will be emailed."} %>
+                      data: {confirm: "Are you sure? The event will start showing for all users, and no one will be emailed since the event organizers have chosen to manually send the announcement email."} %>
       <% end %>
     <% else %>
       <button class="btn" disabled>No Location - Can't Publish!</button>

--- a/app/views/shared/_organizer_action.erb
+++ b/app/views/shared/_organizer_action.erb
@@ -1,5 +1,6 @@
 <div class='organizer-action'>
-  <%= link_to path, class: "organizer-action #{local_assigns[:style] == :inline ? 'organizer-action-inline' : ''}", data: { confirm: local_assigns[:confirm] } do %>
+  <% verb ||= :get %>
+  <%= link_to path, method: verb, class: "organizer-action #{local_assigns[:style] == :inline ? 'organizer-action-inline' : ''}", data: { confirm: local_assigns[:confirm] } do %>
     <div class='organizer-action-button'>
       <i class='<%= icon %>'></i>
       <%= text %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Bridgetroll::Application.routes.draw do
       get "rsvp_preview"
       get "close_rsvps"
       get "reopen_rsvps"
+      post "send_announcement_email"
     end
 
     collection do

--- a/db/migrate/20150902211626_add_announcement_email_sent_at_to_events.rb
+++ b/db/migrate/20150902211626_add_announcement_email_sent_at_to_events.rb
@@ -1,0 +1,5 @@
+class AddAnnouncementEmailSentAtToEvents < ActiveRecord::Migration
+  def change
+    add_column :events, :announcement_email_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150818033729) do
+ActiveRecord::Schema.define(version: 20150902211626) do
 
   create_table "authentications", force: :cascade do |t|
     t.integer  "user_id"
@@ -116,6 +116,7 @@ ActiveRecord::Schema.define(version: 20150818033729) do
     t.string   "target_audience"
     t.boolean  "open",                           default: true
     t.text     "survey_greeting"
+    t.datetime "announcement_email_sent_at"
   end
 
   create_table "external_events", force: :cascade do |t|

--- a/spec/features/announcing_an_event_spec.rb
+++ b/spec/features/announcing_an_event_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+describe "Announcing an event", js: true do
+  let(:user_organizer) { create(:user, email: "organizer@mail.com", first_name: "Sam", last_name: "Spade") }
+  let(:admin) { create(:user, admin: true) }
+  let(:event_location) { create(:location) }
+
+  before do
+    sign_in_as(user_organizer)
+    visit "/events/new"
+    fill_in_good_event_details
+    fill_in 'What population is this workshop reaching out to?', with: "a population"
+    check("coc")
+  end
+
+  context "automatically" do
+    before do
+      choose('event_email_on_approval_true')
+      click_on submit_for_approval_button
+    end
+
+    context "before approval" do
+      it "will not allow the announcement email to be sent by an organizer" do
+        click_on "Organizer Console"
+        expect(page).to have_no_content "Send Announcement Email"
+      end
+    end
+
+    context "after approval" do
+      before do
+        Event.last.update_attribute(:location, event_location)
+
+        sign_in_as admin
+        visit unpublished_events_path
+        click_on "Publish"
+
+        sign_in_as(user_organizer)
+      end
+
+      it "will not allow the announcement to be resent by an organizer" do
+        visit '/'
+        click_on good_event_title
+        click_on "Organizer Console"
+        expect(page).to have_no_content "Send Announcement Email"
+      end
+    end
+  end
+
+  context "manually" do
+    before do
+      choose('event_email_on_approval_false')
+      click_on submit_for_approval_button
+    end
+
+    context "before approval" do
+      it "will not allow the announcement email to be sent by an organizer" do
+        click_on "Organizer Console"
+        expect(page).to have_no_content "Send Announcement Email"
+      end
+    end
+
+    context "after approval" do
+      before do
+        Event.last.update_attribute(:location, event_location)
+
+        sign_in_as admin
+        visit unpublished_events_path
+        click_on "Publish"
+
+        sign_in_as(user_organizer)
+      end
+
+      it "will allow an organizer to send an announcement email" do
+        visit '/'
+        click_on good_event_title
+        click_on "Organizer Console"
+        click_on "Send Announcement Email"
+        expect(page).to have_content "Your announcement email was sent!"
+      end
+
+      it "will not allow an announcement email to be sent more than once by an organizer" do
+        visit '/'
+        click_on good_event_title
+        click_on "Organizer Console"
+        click_on "Send Announcement Email"
+        expect(page).to have_no_content "Send Announcement Email"
+      end
+    end
+  end
+end

--- a/spec/features/new_event_request_spec.rb
+++ b/spec/features/new_event_request_spec.rb
@@ -62,6 +62,12 @@ describe "New Event" do
     expect(Event.last.allowed_operating_systems.count).to eq(OperatingSystem.count - 2)
   end
 
+  it 'allows organizer to choose when to send their announcement email' do
+    page.find('#event_email_on_approval_true')[:checked].should == 'checked'
+    choose('event_email_on_approval_true')
+    choose('event_email_on_approval_false')
+  end
+
   context 'after clicking "Add another session"', js: true do
     before do
       click_on 'Add another session'
@@ -92,12 +98,14 @@ describe "New Event" do
     it 'allows a draft to be saved' do
       fill_in_good_event_details
       fill_in 'event_target_audience', :with => "women"
+      choose('event_email_on_approval_false')
       page.should have_button 'Save Draft'
       click_on 'Save Draft'
 
       page.should have_content('Draft saved')
       page.current_path.should eq '/events'
       page.should have_button 'Save Draft'
+      page.find('#event_email_on_approval_false')[:checked].should == true
 
       visit '/events'
       page.find('.upcoming-events .event-title').text.should match(Regexp.new(good_event_title))


### PR DESCRIPTION
* Event organizers choose manual or automatic sending of announcement emails during event creation.
* A button was added to the organizer console which allows organizers to manually send the announcement email.
* Announcement emails can only be sent once, regardless of whether the automatic or manual option was chosen.
* All future events will know when their announcement email was sent.

https://www.pivotaltracker.com/story/show/99062978