### PR TITLE
show view for archived locations now has an alert

### DIFF
--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -4,7 +4,12 @@
   <div class="col-md-4">
     <%= render "shared/map", location: @location %>
   </div>
-  <div class="col-md-6">
+  <div class="col-md-8">
+    <% if @location.archived_at.present? %>
+      <div class="alert alert-warning">
+        This location is archived, and can no longer be used for events.
+      </div>
+    <% end %>
     <% if @location.chapter.has_leader?(current_user) %>
       <div class="pull-right">Last Updated: <%= @location.updated_at.to_formatted_s(:long) %></div>
     <% end %>


### PR DESCRIPTION
@lilliealbert @tjgrathwell I put an alert at the top of the location details section. What do you think about the locations index view also visually distinguishing between archived and active? Right now the index view is the same as the show page used to be where the only indicator is the missing edit button. Maybe the text for the archived rows can be a medium gray instead of black? 
![screen shot 2015-08-29 at 4 53 14 pm](https://cloud.githubusercontent.com/assets/2976047/9565050/84179300-4e6e-11e5-96e8-b1151d1212b6.png)
