### PR TITLE
Add details to attendees modal

### DIFF
--- a/app/assets/templates/section_organizer/attendee_detail.hbs
+++ b/app/assets/templates/section_organizer/attendee_detail.hbs
@@ -22,6 +22,9 @@
 
         <div class='detail-header'>Operating System</div>
         <div class='detail'>{{operating_system_title}}</div>
+
+        <div class='detail-header'>Class Level Title</div>
+        <div class='detail'>{{level_title}}</div>
       {{/if}}
       {{#if organizer}}
         <div class='role'>Workshop Organizer</div>

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -322,7 +322,12 @@ class Event < ActiveRecord::Base
     self
   end
 
+  def levels
+    course[:levels]
+  end
+
   private
+
 
   DEFAULT_DETAIL_FILES = Dir[Rails.root.join('app', 'models', 'event_details', '*.html')]
   DEFAULT_DETAILS = DEFAULT_DETAIL_FILES.each_with_object({}) do |f, hsh|

--- a/app/models/rsvp.rb
+++ b/app/models/rsvp.rb
@@ -106,6 +106,14 @@ class Rsvp < ActiveRecord::Base
     end
   end
 
+  def level_title
+    level[:title] if role == Role::STUDENT
+  end
+
+  def level
+    event.levels.find {|level| level[:level] == class_level}
+  end
+
   def operating_system_title
     operating_system.try(:title)
   end
@@ -224,7 +232,7 @@ class Rsvp < ActiveRecord::Base
 
   def as_json(options={})
     options[:methods] ||= []
-    options[:methods] |= [:full_name, :operating_system_title, :operating_system_type]
+    options[:methods] |= [:full_name, :operating_system_title, :operating_system_type, :level_title]
     super(options)
   end
 end

--- a/spec/features/attendee_details_spec.rb
+++ b/spec/features/attendee_details_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe "the attendee details modal", js: true do
+  before do
+    @organizer = create(:user)
+
+    @event = create(:event)
+    @event.organizers << @organizer
+    @student_rsvp = create(:student_rsvp, user: create(:user), event: @event)
+
+    sign_in_as(@organizer)
+
+    visit event_organize_sections_path(@event)
+
+    within 'ul.students' do
+      find('i').click
+    end
+  end
+
+  it "should list the student's operating system" do
+    within '.modal-body' do
+      expect(page).to have_content(@student_rsvp.operating_system_title)
+    end
+  end
+
+  it "should list the student's class level title" do
+    within '.modal-body' do
+      expect(page).to have_content(@student_rsvp.level_title)
+    end
+  end
+
+  it "it should list the student's job details" do
+    within '.modal-body' do
+      expect(page).to have_content(@student_rsvp.job_details)
+    end
+  end
+end

--- a/spec/models/rsvp_spec.rb
+++ b/spec/models/rsvp_spec.rb
@@ -182,4 +182,38 @@ describe Rsvp do
       expect(@rsvp.as_json["full_name"]).to eq('Bill Blank')
     end
   end
+
+  describe "#level_title" do
+    let(:event) do
+      build(:event_with_no_sessions).tap do |event|
+        @session_no_options = build(:event_session, event: event, required_for_students: false, volunteers_only: false)
+        event.event_sessions << @session_no_options
+        event.save!
+      end
+    end
+
+    describe "for students" do
+      let(:rsvp) { create(:student_rsvp, event: event) }
+
+      it "returns the level title for a particular student and event" do
+        expect(rsvp.level_title).to eq("Somewhat New to Programming")
+      end
+    end
+
+    describe "for volunteers" do
+      let(:rsvp) { create(:volunteer_rsvp, event: event) }
+
+      it "returns nil" do
+        expect(rsvp.level_title).to be_nil
+      end
+    end
+
+    describe "for organizers" do
+      let(:rsvp) { create(:organizer_rsvp, event: event) }
+
+      it "returns nil" do
+        expect(rsvp.level_title).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
I have added the Class Level Title to the attendee modal that is opened when an organizer clicks on a student. Aside from the specs and from the new `Gemfile.lock`, the changes are as follows:

1. `rsvp.rb` model has two new instance methods - `#level_title` and `#level`.
2. `event.rb` model has one new instance method - `#levels`.
3. `attendee_detail.hbs` template has a new section for the level's title.