### PR TITLE
Add links for email notification of upcoming events to homepage

### DIFF
--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -23,10 +23,15 @@
       <% end %>
     </div>
 
-    <p>
-      Subscribe to our calendar via: 
+    <p class="event-notifications">
+      Subscribe to our calendar via:
       <%= link_to " RSS", feed_events_path(format: :rss), class: 'fa-before fa-rss' %>
-      <%= link_to " Atom", feed_events_path(format: :atom), class: 'fa-before fa-rss' %>
+      <%= link_to " Atom", feed_events_path(format: :atom), class: 'fa-before fa-rss' %> or
+      <% if user_signed_in? %>
+        manage your <%= link_to 'event notification email preferences', edit_user_registration_path %>.
+      <% else %>
+        <%= link_to "sign up", new_user_registration_path %> to receive email notifications.
+      <% end %>
     </p>
 
     <% if user_signed_in? %>

--- a/spec/features/homepage_request_spec.rb
+++ b/spec/features/homepage_request_spec.rb
@@ -23,6 +23,28 @@ describe "visiting the home page" do
       end
       expect(page).to have_content('A message with a confirmation link has been sent to your email address. Please open the link to activate your account.')
     end
+
+    it "has a sign up link in the upcoming events section" do
+      visit '/'
+      within '.event-notifications' do
+        expect(page).to have_link('sign up', new_user_registration_path)
+        expect(page).to have_text('to receive email notifications')
+      end
+    end
+  end
+
+  describe "as an authenticated user" do
+    before do
+      @user = create(:user)
+      sign_in_as(@user)
+    end
+
+    it "has a link to email notification preferences" do
+      visit '/'
+      within '.event-notifications' do
+        expect(page).to have_link('event notification email preferences', edit_user_registration_path)
+      end
+    end
   end
 
   describe "navbar" do


### PR DESCRIPTION
Currently users who visit the home page don't see a way to sign up for email notifications of upcoming events.  This change adds a sign up link below the upcoming events section and text informing the user that they will receive emails if they sign up.
It also adds a link that signed in users see that lets them manage their email notification preferences.