### PR TITLE
Create a new Location from the events/new view via AJAX

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,6 +3,7 @@ class EventsController < ApplicationController
   before_action :find_event, except: [:index, :feed, :create, :new]
   before_action :validate_organizer!, except: [:index, :feed, :create, :show, :new, :levels]
   before_action :set_time_zone, only: [:create, :update]
+  before_action :set_empty_location, only: [:new, :create]
 
   def index
     respond_to do |format|
@@ -86,6 +87,10 @@ class EventsController < ApplicationController
     if params[:event] && params[:event][:time_zone].present?
       Time.zone = params[:event][:time_zone]
     end
+  end
+
+  def set_empty_location
+    @location = Location.new
   end
 
   def find_event

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -19,10 +19,14 @@ class LocationsController < ApplicationController
   def create
     @location = Location.new(location_params)
 
-    if @location.save
-      redirect_to @location, notice: 'Location was successfully created.'
-    else
-      render :new
+    respond_to do |format|
+      if @location.save
+        format.html { redirect_to @location, notice: 'Location was successfully created.'}
+        format.js   {}
+      else
+        format.html { render :new }
+        format.js   { render action: 'create_failed' }
+      end
     end
   end
 

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -36,7 +36,7 @@
       $('#event_location_id').select2();
     </script>
     <p>
-      <em>If your location isn't in this list, head over to the <%= link_to 'locations page', locations_path %> and add it before you continue.</em>
+    <em>If your location isn't in this list, <%= link_to 'add it', '#new-location-modal', 'data-toggle' => 'modal' %> before you continue.</em>
     </p>
   </div>
 
@@ -284,4 +284,8 @@
       <%= f.submit class: 'btn btn-submit coc-required', data: {disable_with: 'Please wait...'} %>
     <% end %>
   </div>
+<% end %>
+
+<% if @event.new_record? %>
+  <%= render "location_modal", modal: true %>
 <% end %>

--- a/app/views/events/_location_modal.html.erb
+++ b/app/views/events/_location_modal.html.erb
@@ -1,0 +1,17 @@
+<div class="modal fade" id="new-location-modal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+        <h4 class="modal-title" id="myModalLabel">New Location</h4>
+      </div>
+      <div class="modal-body" id="new-location-modal-body">
+        <%# Render the new location form (passing modal => true to enable remote => true) %>
+        <%= render 'locations/form', modal: true %>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/locations/_form.html.erb
+++ b/app/views/locations/_form.html.erb
@@ -1,6 +1,14 @@
+<% modal ||= false %>
+<% remote = modal ? true : false %>
+
 <div class="row">
-  <div class="col-md-6">
-    <%= simple_form_for(@location) do |f| %>
+  <% if remote %>
+    <div class="col-md-12">
+  <% else %>
+    <div class="col-md-6">
+  <% end %>
+
+    <%= simple_form_for(@location, remote: remote, html: {role: :form, 'data-model' => 'location'}) do |f| %>
       <%= render 'shared/model_error_messages', model: @location %>
 
       <%= render 'shared/region_select', f: f %>

--- a/app/views/locations/create.js.erb
+++ b/app/views/locations/create.js.erb
@@ -1,0 +1,8 @@
+$('#new-location-modal').modal('hide');
+
+// New location details
+var value = '<%= @location.id %>'
+var name = '<%= @location.name %>'
+var region = '<%= @location.region.name %>'
+
+$('#event_location_id').append('<option value="' + value + '">' + name + ' (' + region + ')</option>');

--- a/app/views/locations/create_failed.js.erb
+++ b/app/views/locations/create_failed.js.erb
@@ -1,0 +1,1 @@
+$('#new-location-modal-body').html('<%= j render "form", modal: true %>')

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -197,6 +197,12 @@ describe EventsController do
         get :new
         expect(assigns(:event).time_zone).to eq('Alaska')
       end
+
+      it "assigns an empty location" do
+        get :new
+        expect(assigns(:location)).to be_new_record
+        expect(response).to be_success
+      end
     end
   end
 

--- a/spec/controllers/locations_controller_spec.rb
+++ b/spec/controllers/locations_controller_spec.rb
@@ -4,7 +4,7 @@ describe LocationsController do
   before do
     @location = create(:location)
   end
-  
+
   describe "permissions" do
     context "a user that is not logged in" do
       it "can not edit or destroy a location" do
@@ -79,6 +79,21 @@ describe LocationsController do
         expect {
           perform_update_request
         }.not_to change { @location.reload.name }
+      end
+    end
+
+    describe '#create (remote)' do
+      let(:post_req) { post :create, format: 'js', location: location_attrs }
+      let(:location_attrs) { attributes_for(:location) }
+
+      it "should return javascript" do
+        post_req
+        expect(response.content_type).to eq('text/javascript')
+      end
+
+      it "respond successfully with an HTTP 200 status code" do
+        post_req
+        expect(response).to have_http_status(200)
       end
     end
 


### PR DESCRIPTION
Create a new location via a modal on the events/new view via AJAX,
eliminating the need for a page refresh.

This was done by using unobtrusive javascript, a bootstrap modal, and
code to that adds the ability of the location controller to respond to
javascript requests. The major changes are as follows:

1. The Events controller now sets an empty location for the new and
create action. This is necessary to properly render the location form.

2. The location controller now responds to both HTML and JS requests.

3. A location modal, which renders a new location form partial, has been
added to the `events/_form partial` if `@event.new_record?`.

4. A location modal partial has been created within the `views/events`
folder.  This modal invokes the `locations/_form` partial. By splitting
out the modal, we are able to only include it if `@event.new_record?` is
true.

5. The `locations_/form` partial now has its remote option set to true if
it is being rendered from `events/_form`.

6. Two new files, `create.js.erb` and `create_failed.js.erb` have been so
that the Location controller can respond with Javascript if the `#create`
action receives a javascript request.

7. A full test-suit for this feature is included.