### PR TITLE
Organizers can preview survey before sending it to participants

### DIFF
--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -1,7 +1,7 @@
 class SurveysController < ApplicationController
   before_action :authenticate_user!
   before_action :find_event
-  before_action :find_rsvp, except: [:index]
+  before_action :find_rsvp, except: :index
   before_action :validate_user!, except: [:index, :preview]
   before_action :validate_organizer!, only: :index
 

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -1,8 +1,8 @@
 class SurveysController < ApplicationController
   before_action :authenticate_user!
   before_action :find_event
-  before_action :find_rsvp, except: :index
-  before_action :validate_user!, except: :index
+  before_action :find_rsvp, except: [:index]
+  before_action :validate_user!, except: [:index, :preview]
   before_action :validate_organizer!, only: :index
 
   def new
@@ -28,6 +28,12 @@ class SurveysController < ApplicationController
   def index
     @student_surveys = Survey.where(rsvp_id: @event.rsvps.where(role_id: Role::STUDENT.id).pluck(:id))
     @volunteer_surveys = Survey.where(rsvp_id: @event.volunteer_rsvps.pluck(:id))
+  end
+
+  def preview
+    @survey = Survey.new
+    @preview = true
+    render :new
   end
 
   private

--- a/app/views/events/organizer_tools/index.html.erb
+++ b/app/views/events/organizer_tools/index.html.erb
@@ -69,6 +69,7 @@
 
 
     <h2>Tools for after the event</h2>
+    <p>We encourage you to send this quick survey to everyone who participated.</p>
     <% if @event.survey_sent? %>
       <section class="organizer-dashboard-section">
         <%= render partial: 'shared/organizer_action', locals: {
@@ -81,11 +82,10 @@
     <% else %>
       <section class="organizer-dashboard-section">
         <%= render partial: 'shared/organizer_action', locals: {
-          path: event_send_survey_email_path(@event),
+          path: preview_event_surveys_path(@event),
           icon: 'fa fa-envelope',
-          text: 'Send Survey',
-          tip: 'Click here to send a link to the follow up survey to all students and volunteers.',
-          confirm: 'Are you sure?'
+          text: 'Preview & Send Survey',
+          tip: 'Email all students and volunteers with a short follow-up survey.',
         } %>
         <%= render partial: 'shared/organizer_action', locals: {
           path: edit_event_survey_path(@event),
@@ -97,5 +97,3 @@
     <% end %>
   </div>
 </div>
-
-

--- a/app/views/surveys/new.html.erb
+++ b/app/views/surveys/new.html.erb
@@ -1,25 +1,37 @@
-<%= content_for(:header_text, "Follow-up Survey") %>
+<%= content_for(:header_text, @event.title) %>
 
 <%= render 'shared/model_error_messages', model: @survey %>
 
+<% if @preview %>
+  <%= render :partial => 'shared/organizer_breadcrumb', locals: {current_page_title: 'Survey Preview'} %>
+<% end %>
+
 <h2>How was <%= @event.title %>?</h2>
+
 <p>We love feedback, so let us know how things went for you and anything you think we could make better in the future!</p>
 
 <div class="row">
   <div class="col-md-6 survey-form">
     <%= simple_form_for @survey, url: event_rsvp_surveys_path(@event.id, @rsvp.id) do |f| %>
-      <%= f.input :good_things, label: "What was great?" %>
+      <%= f.input :good_things, label: "What was great?", readonly: @preview %>
 
-      <%= f.input :bad_things, label: "What could have been better?" %>
+      <%= f.input :bad_things, label: "What could have been better?", readonly: @preview  %>
 
-      <%= f.input :other_comments, label: "Any other comments?" %>
+      <%= f.input :other_comments, label: "Any other comments?", readonly: @preview  %>
 
       <%= f.label :recommendation_likelihood, "How likely are you to recommend this workshop to a friend or colleague? (10 is very likely, 1 is unlikely)" %>
-      <%= f.select :recommendation_likelihood, (1..10).to_a.reverse, {}, {class: 'form-control'} %>
-
-      <% unless @survey.persisted? %>
+      <%= f.select :recommendation_likelihood, (1..10).to_a.reverse, {}, {class: 'form-control', disabled: @preview}  %>
+      <% if !@survey.persisted? && !@preview%>
         <%= f.submit "Submit", class: "btn", data: {disable_with: 'Please wait...'} %>
       <% end %>
+      <p></p>
+      <% if @preview && @event.survey_sent?%>
+        <p>Survey has been sent.</p>
+        <% elsif @preview %>
+        <p><%= link_to 'Send Survey', event_send_survey_email_path(@event), class: "btn", :data => {:confirm => 'Are you sure?'} %></p>
+        <p><%= link_to 'Back', event_organizer_tools_path(@event), class: "btn" %></p>
+      <% end %>
+
     <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Bridgetroll::Application.routes.draw do
     resources :region_leaderships, only: [:index, :create, :destroy]
   end
 
+  get "/events/:event_id/surveys/preview" => "surveys#preview", as: :survey_preview
+
   resources :events do
     resources :organizers, only: [:index, :create, :destroy] do
       get :potential, on: :collection
@@ -48,7 +50,9 @@ Bridgetroll::Application.routes.draw do
       resources :surveys, only: [:new, :create]
     end
 
-    resources :surveys, only: [:new, :index]
+    resources :surveys, only: [:new, :index] do
+      get :preview, on: :collection
+    end
 
     resources :event_sessions, only: [:index, :show, :destroy] do
       resources :checkins, only: [:index, :create, :destroy]

--- a/spec/features/event_survey_spec.rb
+++ b/spec/features/event_survey_spec.rb
@@ -7,6 +7,21 @@ describe 'the post-workshop survey' do
     @rsvp = create(:rsvp, user: @user, event: @event)
   end
 
+  describe 'previewing survey' do
+    before do
+      sign_in_as @user
+      visit preview_event_surveys_path(@event)
+    end
+
+    it 'should not allow organizer to submit survey' do
+      expect(page).not_to have_content("Submit")
+    end
+
+    it 'should allow organizer to email RSVPs the survey' do
+      expect(page).to have_content("Send Survey")
+    end
+  end
+
   describe 'taking a survey' do
     before do
       sign_in_as @user


### PR DESCRIPTION
Fixes https://github.com/railsbridge/bridge_troll/issues/372. From the "organizer's console," in the "after event" section, an organizer may preview the survey before sending it to the RSVP'd participants. 