### PR TITLE
Create security list, Rename attendee names and student details

### DIFF
--- a/app/controllers/events/attendee_names_controller.rb
+++ b/app/controllers/events/attendee_names_controller.rb
@@ -1,0 +1,34 @@
+require "csv"
+
+class Events::AttendeeNamesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :find_event
+
+  def index
+    authorize @event, :edit?
+
+    rsvps = @event.rsvps.where(role_id: Role.attendee_role_ids_with_organizers)
+
+    respond_to do |format|
+      format.csv do
+        send_data(attendee_csv_data(rsvps), type: :csv)
+      end
+    end
+  end
+
+  private
+
+  def find_event
+    @event = Event.find_by_id(params[:event_id])
+  end
+
+  def attendee_csv_data(rsvps)
+    CSV.generate do |csv|
+      csv << ['Last Name', 'First Name']
+
+      rsvps.includes(:user).joins(:bridgetroll_user).order('users.last_name ASC, users.first_name ASC').each do |rsvp|
+        csv << [rsvp.user.last_name, rsvp.user.first_name]
+      end
+    end
+  end
+end

--- a/app/views/events/attendees/index.html.erb
+++ b/app/views/events/attendees/index.html.erb
@@ -7,14 +7,24 @@
 <%= render partial: 'shared/organizer_action', locals: {
   path: event_attendees_path(@event, format: :csv),
   icon: 'fa fa-download',
-  text: 'Download Attendee Names CSV',
-  style: :inline
+  text: 'Download all attendee info',
+  style: :inline,
+  tip: "Includes name, role, dietary info, childcare info, job details, gender, plus-one host, if they are waitlisted, and waitlist position for all RSVP'd attendees."
 } %>
 <%= render partial: 'shared/organizer_action', locals: {
   path: event_students_path(@event, format: :csv),
   icon: 'fa fa-download',
-  text: 'Download Student Details CSV',
-  style: :inline
+  text: 'Download basic student info',
+  style: :inline,
+  tip: 'Includes name, class level, operating system, occupation, and gender for all students.'
+} %>
+
+<%= render partial: 'shared/organizer_action', locals: {
+  path: event_attendee_names_path(@event, format: :csv),
+  icon: 'fa fa-download',
+  text: 'Download all names for building security',
+  style: :inline,
+  tip: 'You can use this to download a list of attendees which can be printed out for the security desk.'
 } %>
 </section>
 

--- a/app/views/events/organizer_tools/index.html.erb
+++ b/app/views/events/organizer_tools/index.html.erb
@@ -46,13 +46,6 @@
       and volunteers as they arrive so that you can take care of other things.'
     } %>
 
-    <%= render partial: 'shared/organizer_action', locals: {
-      path: event_attendees_path(@event, format: :csv),
-      icon: 'fa fa-download',
-      text: 'Download Attendee Names CSV',
-      tip: 'You can use this to download a list of attendees which can be printed out for the security desk.'
-    } %>
-
     <%= render partial: 'shared/checkin_event_sessions' %>
 
     <section class='organizer-dashboard-section'>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Bridgetroll::Application.routes.draw do
 
     resources :students, only: [:index], controller: 'events/students'
     resources :attendees, only: [:index, :update], controller: 'events/attendees'
+    resources :attendee_names, only: [:index], controller: 'events/attedee_names'
     resources :emails, only: [:new, :create, :show], controller: 'events/emails'
 
     resources :sections, only: [:create, :update, :destroy] do

--- a/spec/features/event_organizer_dashboard_request_spec.rb
+++ b/spec/features/event_organizer_dashboard_request_spec.rb
@@ -57,7 +57,8 @@ describe "the organizer dashboard" do
     visit event_organizer_tools_path(@event)
     click_link 'Show all Attendee RSVP Details'
 
-    click_link 'Download Student Details CSV'
+    click_link 'Download basic student info'
+
 
     csv_contents = page.source
     expect(csv_contents).to include("Student Name")


### PR DESCRIPTION
Fixes #449
 * Removed download attendee button from organizer tools index
 * Allow event organizers to download a list of student names
 * Renamed security_list to student_names
 * Fixed Download basic student info test

Deprecates #450