### PR TITLE
Issue #461 - Add approve button to event#show

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -36,6 +36,7 @@ class EventsController < ApplicationController
     skip_authorization
     if user_signed_in? && !@event.historical?
       @can_edit = policy(@event).update?
+      @can_publish = policy(@event).publish?
       @checkiner = @event.checkiner?(current_user)
     else
       @organizer = false
@@ -49,6 +50,12 @@ class EventsController < ApplicationController
       Role::VOLUNTEER => @event.ordered_rsvps(Role::VOLUNTEER, waitlisted: true).to_a,
       Role::STUDENT => @event.ordered_rsvps(Role::STUDENT, waitlisted: true).to_a
     }
+    regions = Region.includes(:users)
+                 .where('users.allow_event_email = ?', true)
+                 .references(:users)
+    @region_user_counts = regions.each_with_object({}) do |region, hsh|
+      hsh[region.id] = region.users.length
+    end
   end
 
   def new

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -11,6 +11,25 @@
       <% elsif @checkiner %>
         <%= link_to 'Checkin Console', event_event_sessions_path(@event), class: "btn" %>
       <% end %>
+
+      <% if @can_publish && !@event.published? %>
+        <% if @event.location %>
+          <% if @event.email_on_approval %>
+            <%= link_to 'Publish', unpublished_event_publish_path(@event, send_mail: true), class: 'btn fa-before', method: :post,
+                          data: {confirm: "Are you sure? This will email #{pluralize(@region_user_counts[@event.location.region.id], 'member')} of #{@event.location.region.name}"} %>
+          <% else %>
+            <%= link_to 'Publish', unpublished_event_publish_path(@event), class: 'btn fa-before', method: :post,
+                          data: {confirm: "Are you sure? The event will start showing for all users, and no one will be emailed since the event organizers have chosen to manually send the announcement email."} %>
+          <% end %>
+        <% else %>
+          <button class="btn" disabled>No Location - Can't Publish!</button>
+        <% end %>
+
+      <% if current_user.admin? || current_user.publisher? %>
+        <%= link_to 'Flag as Spam', unpublished_event_flag_path(@event), class: 'btn btn-danger', method: :post,
+                      data: {confirm: "Are you sure? This will remove this event from the approval page, and flag #{@event.organizers.first.full_name} as a spammer so that all subsequent events they create will immediately be flagged as spam."} %>
+      <% end %>
+    <% end %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
This issue asks to give admins and others with publishing permissions the ability to do so from the Event#show itself, and not just the unpublished events index.  

-- The publish and flag buttons were copied from the unpublished events partial and placed in the header alongside the edit and organizer panel buttons.
-- events_controller edited to provide region information necessary for publish action and to query the event policy for correct publishing permissions to properly scope the view

![screen shot 2016-05-03 at 3 03 48 pm](https://cloud.githubusercontent.com/assets/16156605/14999951/3936683e-1141-11e6-8487-c08441f2a3d7.png)