### PR TITLE
Attendee sees name of class section on home page

### DIFF
--- a/app/views/shared/_rsvp_actions.html.erb
+++ b/app/views/shared/_rsvp_actions.html.erb
@@ -8,6 +8,7 @@
   <% elsif event.student?(current_user) %>
     You are signed up to attend this event!
   <% end %>
+  <%= event.rsvp_for_user(current_user).section.try(:name) %>
 </div>
 <% if event.attendee?(current_user) %>
   <%= link_to 'Edit RSVP', edit_event_rsvp_path(event, event.rsvp_for_user(current_user)), class: 'btn' %>

--- a/spec/features/attendee_views_class_section_spec.rb
+++ b/spec/features/attendee_views_class_section_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe 'attendee views class section' do
+
+    it 'shows the class level and room on the upcoming events page' do
+
+      chapter = create(:chapter)
+      @event = create(:event, chapter: chapter)
+      @user = create(:user)
+      sign_in_as @user
+
+      visit volunteer_new_event_rsvp_path(@event)
+
+      fill_in "rsvp_subject_experience", with: "asdfasdfasdfasd"
+      fill_in "rsvp_teaching_experience", with: "asdfasdfasdfasd"
+      choose Course.find_by_name('RAILS').levels[0][:title]
+
+      check('coc')
+      click_on 'Submit'
+
+      #save_and_open_page
+
+      section = @event.sections.create(name: "room A", class_level: 2)
+      rsvp = @user.rsvps.find_by(event: @event)
+      rsvp.update_attribute(:section_id, section.id)
+      visit(root_path)
+
+      expect(page).to have_content("room A")
+      expect(page).to have_content("orange")
+    end
+
+end


### PR DESCRIPTION
We decided to show this here because we thought that it would make it easier for people to see where to go if they can't read the screen at the beginning of the workshop. There is still some work to be done to finish this feature:
- use factories for the test setup instead of going through the UI
- show the color of their class level with the description of what that class level means

Connects #324 
