### PR TITLE
Remove button styling from "Sign Up" link

### DIFF
--- a/app/views/shared/_sign_in.html.erb
+++ b/app/views/shared/_sign_in.html.erb
@@ -10,7 +10,7 @@
 
       <div>
         <%= f.submit "Sign in", class: 'btn btn-submit' %>
-        <%= link_to "Sign up", new_registration_path(resource_name), class: 'btn btn-primary sign_up_link' %>
+        <%= link_to "Sign up", new_registration_path(resource_name), class: 'sign_up_link' %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
I was surprised by the modal - after filling in my email and a password and clicking "Sign Up", I was taken to a longer form that didn't retain that info. I thought this would be a nice little UX stopgap, to make the link look like a link until someone wants to take a crack at the fiddly task of having it carried over.
