### PR TITLE
add volunteer interest to rsvp

### DIFF
--- a/app/controllers/rsvps_controller.rb
+++ b/app/controllers/rsvps_controller.rb
@@ -116,6 +116,7 @@ class RsvpsController < ApplicationController
       else
         @rsvp.user.region_ids -= [@event.region.id]
       end
+
     end
   end
 

--- a/app/models/rsvp.rb
+++ b/app/models/rsvp.rb
@@ -1,7 +1,7 @@
 class Rsvp < ActiveRecord::Base
   include PresenceTrackingBoolean
 
-  PERMITTED_ATTRIBUTES = [:subject_experience, :teaching, :taing, :teaching_experience, :teaching_experience, :childcare_info, :operating_system_id, :job_details, :class_level, :dietary_info, :needs_childcare, :plus_one_host]
+  PERMITTED_ATTRIBUTES = [:subject_experience, :teaching, :taing, :teaching_experience, :teaching_experience, :childcare_info, :operating_system_id, :job_details, :class_level, :dietary_info, :needs_childcare, :plus_one_host, :volunteer_interest]
 
   belongs_to :bridgetroll_user, class_name: 'User', foreign_key: :user_id
   belongs_to :meetup_user, class_name: 'MeetupUser', foreign_key: :user_id

--- a/app/views/events/attendees/index.html.erb
+++ b/app/views/events/attendees/index.html.erb
@@ -42,6 +42,7 @@
         <th class='attendee-gender'>Gender</th>
         <th class='attendee-dietary-info'>Plus-One Host</th>
         <th class='attendee-waitlisted'>Waitlisted</th>
+        <th class='attendee-volunteer-interest'>Volunteer Interest</th>
         <th>Remove RSVP</th>
       </tr>
     </thead>
@@ -58,7 +59,8 @@
           <td data-label="Job details:"><%= rsvp.job_details %></td>
           <td data-label="Gender:"><%= rsvp.user.gender %></td>
           <%= content_tag_maybe_hidden(:td, rsvp.plus_one_host, 'data-label' => 'Plus-one host:') %>
-          <td data-label="Waitlisted?:"><%= if rsvp.waitlist_position then "yes" else "no" end %></td>
+          <td data-label="Waitlisted?:"><%= rsvp.waitlist_position ? "yes" : "no" %></td>
+          <td data-label="Volunteer Interest:"><%= rsvp.volunteer_interest ? "yes" : "no" %></td>
           <td><%= link_to 'Destroy', [rsvp.event, rsvp], method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' %></td>
           </tr>
         <% end %>

--- a/app/views/rsvps/_form.html.erb
+++ b/app/views/rsvps/_form.html.erb
@@ -143,10 +143,22 @@
         <div class="form-group boolean optional affiliate_with_region">
           <div class="checkbox">
             <%= label_tag :affiliate_with_region do %>
-              <%= check_box_tag :affiliate_with_region, 1, current_user.regions.include?(@event.region) %> I want to be notified of future events in the "<%= @event.region.name %>" region.
+              <%= check_box_tag :affiliate_with_region, 1, current_user.regions.include?(@event.region) %> I want to be notified of future events in the <%= @event.region.name %> region.
             <% end %>
             <div>
               <small>(Full email preferences are available <%= link_to 'on your User Account', edit_user_registration_path %>)</small>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="field question">
+        <div class="form-group boolean optional affiliate_with_region">
+          <div class="checkbox">
+            <%= f.label :volunteer_interest, class: 'checkbox' do %>
+              <%= f.check_box :volunteer_interest, class: 'volunteer_interest' %> I can help with future events in <%= @event.region.name %>. 
+            <% end %>
+            <div>
+              <small>(This could involve organizing, scouting venues and sponsors, helping with workshop outreach, or other things!)</small>
             </div>
           </div>
         </div>

--- a/db/migrate/20160730222752_add_volunteer_interest_to_rsvps.rb
+++ b/db/migrate/20160730222752_add_volunteer_interest_to_rsvps.rb
@@ -1,0 +1,5 @@
+class AddVolunteerInterestToRsvps < ActiveRecord::Migration
+  def change
+  	add_column :rsvps, :volunteer_interest, :boolean, default: false, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160710221707) do
+ActiveRecord::Schema.define(version: 20160730222752) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -254,6 +254,7 @@ ActiveRecord::Schema.define(version: 20160710221707) do
     t.boolean  "checkiner",                           default: false
     t.text     "plus_one_host"
     t.string   "token"
+    t.boolean  "volunteer_interest",                  default: false
   end
 
   add_index "rsvps", ["token"], name: "index_rsvps_on_token", unique: true


### PR DESCRIPTION
This PR adds a volunteer interest checkbox to the Rsvp form and migrates the Rsvp table to contain a volunteer interest boolean. This can be viewed in the organizer attendee details panel.
https://github.com/railsbridge/bridge_troll/issues/443
PTAL