### PR TITLE
Fix bin/setup db:seed mixup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -64,7 +64,8 @@ Dir.chdir APP_ROOT do
     system "bin/rake db:migrate"
   else
     puts "Database not found, initializing..."
-    system "bin/rake db:setup"
+    system "bin/rake db:create"
+    system "bin/rake db:schema:load"
   end
 
   puts "Initialization complete, run `rake db:seed` to add sample events, if desired."


### PR DESCRIPTION
On a fresh setup of the app in a new dev environment, `bin/setup` will run `rake db:setup`, then complete and prompt the user to run `rake db:seed` to add sample events. Because `rake db:setup` runs `rake db:seed` itself, running it again will produce the following error:

```
rake aborted!
ActiveRecord::RecordInvalid: Validation failed: Email has already been taken
```

This happens because the seed data already exists. To fix, I've edited `bin/setup` to run `rake db:create` and `rake db:schema:load` instead of `rake db:setup`. This continues to allow the user to decide if they would like to have seed data or not.

Thanks, and please do let me know if there's anything else you need from me regarding this issue!