### PR TITLE
infer event time zone based on location

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'icalendar'
 gem 'pg' if ENV['FORCE_POSTGRES']
 gem 'rack-mini-profiler'
 gem 'bower-rails'
+gem 'nearest_time_zone'
 
 group :production do
   gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
+    andand (1.3.3)
     arel (6.0.3)
     autoprefixer-rails (6.5.0.2)
       execjs
@@ -159,6 +160,7 @@ GEM
       railties (>= 3.2.16)
     json (1.8.3)
     jwt (1.5.6)
+    kdtree (0.3)
     launchy (2.4.3)
       addressable (~> 2.3)
     loofah (2.0.3)
@@ -173,6 +175,10 @@ GEM
     multi_json (1.12.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
+    nearest_time_zone (0.0.4)
+      andand
+      kdtree
+      require_all
     nested_form (0.3.2)
     newrelic_rpm (3.16.3.323)
     nokogiri (1.6.8.1)
@@ -263,6 +269,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (11.3.0)
     rb-fsevent (0.9.7)
+    require_all (1.3.3)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
     rspec-collection_matchers (1.1.2)
@@ -366,6 +373,7 @@ DEPENDENCIES
   jquery-rails
   jquery-ui-rails
   launchy
+  nearest_time_zone
   nested_form
   newrelic_rpm
   omniauth-facebook

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -37,6 +37,13 @@ module EventsHelper
     @event.organizers_with_legacy.empty? ? [] : @event.organizers_with_legacy
   end
 
+  def locations_for_select
+    Location.includes(:region).available.map do |loc|
+      time_zone = ActiveSupport::TimeZone::MAPPING.key(loc.inferred_time_zone)
+      [loc.name_with_region, loc.id, prompt: true, 'data-inferred-time-zone' => time_zone]
+    end
+  end
+
   def formatted_event_date(event)
     l event.date_in_time_zone(:starts_at), format: :date_as_day_mdy
   end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -67,6 +67,11 @@ class Location < ActiveRecord::Base
     end
   end
 
+  def inferred_time_zone
+    return nil unless latitude && longitude
+    NearestTimeZone.to(latitude, longitude)
+  end
+
   def reset_events_count
     update_column(:events_count, all_events.count)
   end

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -147,11 +147,11 @@
       <div>
         <%= f.label :location_id, label: 'Event Location' %>
       </div>
-      <%= f.collection_select(:location_id,
-                              Location.includes(:region).available,
-                              :id,
-                              :name_with_region,
-                              {prompt: true}) %>
+      <%= f.select(:location_id,
+                   locations_for_select,
+                   include_blank: 'Please select',
+                   onchange: "$('#event_time_zone').val(this.selectedOptions[0].dataset.inferredTimeZone)"
+                  ) %>
       <script>
         window.whenReady(function () {
           $('#event_location_id').select2({width: '100%'});

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -68,4 +68,17 @@ describe Location do
       end
     end
   end
+
+  describe 'inferred time zone' do
+    let!(:location) { create(:location) }
+    it 'infers time zone from latitude and longtidue' do
+      location.latitude = 45
+      location.longitude = 45
+      expect(location.inferred_time_zone).to eq('Europe/Moscow')
+    end
+
+    it 'does not infer time zone when latitude and longitude are not present' do
+      expect(location.inferred_time_zone).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
This is a PR for issue #390. When an event is being created or edited, the timezone field will automatically update if the selected location is changed. I used the gem that @StevenXL recommended to suggest the time zone of an event based on the latitude and longitude of its location, if available. 

This does not include any changes to the underlying associations or validations between events and locations. I felt that this small change to the event form was sufficient for the problem that the original issue described, but I can definitely add to this if more general timezone inferring would be useful.
