### PR TITLE
Show childcare requests even if childcare is disabled

### DIFF
--- a/app/views/events/organizer_tools/_childcare_requests.html.erb
+++ b/app/views/events/organizer_tools/_childcare_requests.html.erb
@@ -1,4 +1,7 @@
 <h3>Childcare Requests</h3>
+<% if !@event.has_childcare %>
+  Childcare sign ups are currently disabled.
+<% end %>
 <% if @childcare_requests.length > 0 %>
   <table class="table responsive-table">
     <thead>

--- a/app/views/events/organizer_tools/index.html.erb
+++ b/app/views/events/organizer_tools/index.html.erb
@@ -20,11 +20,9 @@
       <%= render partial: 'events/organizer_preworkshop_buttons' %>
     </section>
 
-    <% if @event.has_childcare? %>
-      <section class='organizer-dashboard-section bordered'>
-        <%= render partial: 'childcare_requests' %>
-      </section>
-    <% end %>
+    <section class='organizer-dashboard-section bordered'>
+      <%= render partial: 'childcare_requests' %>
+    </section>
 
     <section class='organizer-dashboard-section bordered'>
       <%= render partial: 'checkin_counts' %>
@@ -59,7 +57,6 @@
         title to the section.'
       } %>
     </section>
-
 
     <h2>Tools for after the event</h2>
     <p>We encourage you to send this quick survey to everyone who participated.</p>


### PR DESCRIPTION
The problem:

Oftentimes we want to provide childcare for an event but disable it
shortly before the event so that we can provide an accurate count to
the babysitter and don't need to worry about last minute signups.
Unfortunately this removes the previous childcare signup information
from the organizer console, so that once childcare is disabled we no
longer have access to the information for those who have already
requested childcare.

The solution:

This makes it so that childcare signup information is shown even if childcare
is disabled for the event. A message is shown to let the user know if
childcare is disabled.

Now, if you disable childcare but have previous signups you'll see this: 
![image](https://cloud.githubusercontent.com/assets/8496209/20491067/2d103972-afde-11e6-8c78-eec984374271.png)

If childcare is disabled and there were no previous signups you'll see this: 
![image](https://cloud.githubusercontent.com/assets/8496209/20491079/38819e5e-afde-11e6-8c2c-106983d53b98.png)
