### PR TITLE
add 'rack cors' for cross origin requests and grant 'bridgefoundry.or…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'icalendar'
 gem 'rack-mini-profiler'
 gem 'bower-rails'
 gem 'nearest_time_zone'
+gem 'rack-cors'
 
 group :production do
   gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,6 +238,7 @@ GEM
     rack-canonical-host (0.2.2)
       addressable (> 0, < 3)
       rack (>= 1.0.0, < 3)
+    rack-cors (0.4.1)
     rack-mini-profiler (0.10.1)
       rack (>= 1.2.0)
     rack-test (0.6.3)
@@ -398,6 +399,7 @@ DEPENDENCIES
   pundit
   quiet_assets
   rack-canonical-host
+  rack-cors
   rack-mini-profiler
   rack-timeout
   rails (~> 4.2.7)

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,5 +32,13 @@ module Bridgetroll
     config.to_prepare do
       Devise::Mailer.layout "mailer"
     end
+
+    # allow cross origin requests from BridgeFoundry
+    config.middleware.insert_before 0, "Rack::Cors" do
+      allow do
+        origins 'bridgefoundry.org'
+        resource '/events.json', :headers => :any, :methods => [:get]
+      end
+    end
   end
 end


### PR DESCRIPTION
…g' access to 'events.json'

Resolves part of issue #499.