### PR TITLE
Ensure dates are sorted in regions show events table

### DIFF
--- a/app/views/shared/_events_table.html.erb
+++ b/app/views/shared/_events_table.html.erb
@@ -28,7 +28,7 @@
         <% end %>
         <%= imported_event_popover_trigger(event) %>
       </td>
-      <td class='whitespace-nowrap'>
+      <td class='whitespace-nowrap' data-order='<%= event.starts_at.to_datetime.to_i %>'>
         <%= formatted_event_date(event) %>
       </td>
       <% if event.location %>

--- a/db/seeds/seed_event.rb
+++ b/db/seeds/seed_event.rb
@@ -240,8 +240,8 @@ module Seeder
         This is an example of an event that takes place in multiple locations!
       DETAILS
     )
-    event.event_sessions << EventSession.new(name: 'Teacher Training', starts_at: 60.days.from_now, ends_at: 61.days.from_now, location: session_location)
-    event.event_sessions << EventSession.new(name: 'Workshop', starts_at: 65.days.from_now, ends_at: 66.days.from_now)
+    event.event_sessions << EventSession.new(name: 'Teacher Training', starts_at: 80.days.from_now, ends_at: 81.days.from_now, location: session_location)
+    event.event_sessions << EventSession.new(name: 'Workshop', starts_at: 85.days.from_now, ends_at: 86.days.from_now)
 
     event.save!
 


### PR DESCRIPTION
I noticed, when viewing events on the regions page, that the sorting of the dates was wrong.
This PR addresses that.

@peterylai and @ams340 worked on this with me.
