### PR TITLE
Add ability for events to specify a custom_question to be answered on…

### DIFF
--- a/app/controllers/events/attendees_controller.rb
+++ b/app/controllers/events/attendees_controller.rb
@@ -31,17 +31,18 @@ class Events::AttendeesController < ApplicationController
   def attendee_csv_data(rsvps)
     CSV.generate do |csv|
       csv << [
-        'Name', 'Attending As', 'Dietary Info', 'Childcare Info',
-        'Job Details', 'Gender', 'Plus-One Host', 'Waitlisted',
-        'Waitlist Position'
+        'Name', 'Attending As', 'Custom Question Answer', 'Dietary Info',
+        'Childcare Info', 'Job Details', 'Gender', 'Plus-One Host',
+        'Waitlisted', 'Waitlist Position'
       ]
 
       rsvps.includes(:user).joins(:bridgetroll_user).order('users.first_name ASC, users.last_name ASC').each do |rsvp|
         waitlisted = rsvp.waitlisted? ? 'yes' : 'no'
         csv << [
-          rsvp.user.full_name, rsvp.role.title, rsvp.full_dietary_info,
-          rsvp.childcare_info, rsvp.job_details, rsvp.user.gender,
-          rsvp.plus_one_host, waitlisted, rsvp.waitlist_position
+          rsvp.user.full_name, rsvp.role.title, rsvp.custom_question_answer,
+          rsvp.full_dietary_info, rsvp.childcare_info, rsvp.job_details,
+          rsvp.user.gender, rsvp.plus_one_host, waitlisted,
+          rsvp.waitlist_position
         ]
       end
     end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -392,6 +392,10 @@ class Event < ActiveRecord::Base
     course.levels
   end
 
+  def asks_custom_question?
+    custom_question.present?
+  end
+
   private
 
   DEFAULT_DETAIL_FILES = Dir[Rails.root.join('app', 'models', 'event_details', '*.html')]

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -69,6 +69,7 @@ class EventPolicy < ApplicationPolicy
       :has_childcare,
       :restrict_operating_systems,
       :survey_greeting,
+      :custom_question,
       {
         event_sessions_attributes: EventSessionPolicy.new(user, EventSession).permitted_attributes + [:id],
         allowed_operating_system_ids: []

--- a/app/policies/rsvp_policy.rb
+++ b/app/policies/rsvp_policy.rb
@@ -14,6 +14,7 @@ class RsvpPolicy < ApplicationPolicy
       :operating_system_id,
       :job_details,
       :class_level,
+      :custom_question_answer,
       :dietary_info,
       :needs_childcare,
       :plus_one_host,

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -318,7 +318,10 @@
 
     <div>
       <%= f.input :volunteer_details, label: 'RSVP confirmation details sent to Volunteers after sign up', input_html: {rows: 4} %>
+    </div>
 
+    <div>
+      <%= f.input :custom_question, label: 'Anything else you want to ask users who RSVP? (e.g., t-shirt size)', input_html: {rows: 4} %>
     </div>
   <% end %>
 

--- a/app/views/events/attendees/index.html.erb
+++ b/app/views/events/attendees/index.html.erb
@@ -36,6 +36,7 @@
       <tr>
         <th class='attendee-name'>Name</th>
         <th class='attendee-role'>Attending As</th>
+        <th class='attendee-custom-question-answer'>Custom Question Answer</th>
         <th class='attendee-dietary-info'>Dietary Info</th>
         <th class='attendee-childcare-info'>Childcare Info</th>
         <th class='attendee-job-details'>Job Details</th>
@@ -53,6 +54,7 @@
             <%= link_to rsvp.user.full_name, user_profile_path(rsvp.user) %>
           </td>
           <td data-label="Attending as:"><%= rsvp.role.title %></td>
+          <%= content_tag_maybe_hidden(:td, rsvp.custom_question_answer, 'data-label' => 'Custom question answer:') %>
           <%= content_tag_maybe_hidden(:td, rsvp.full_dietary_info, 'data-label' => 'Dietary info:') %>
           <%= content_tag_maybe_hidden(:td, rsvp.childcare_info, 'data-label' => 'Childcare info:') %>
           <td data-label="Job details:"><%= rsvp.job_details %></td>

--- a/app/views/rsvps/_form.html.erb
+++ b/app/views/rsvps/_form.html.erb
@@ -117,6 +117,12 @@
       <% end %>
     </div>
 
+    <% if @event.asks_custom_question? %>
+      <div class="field question">
+        <%= f.input :custom_question_answer, label: @event.custom_question, input_html: {rows: 3} %>
+      </div>
+    <% end %>
+
     <% if @event.food_provided? %>
       <div class="field">
         <p class="question">The food's on us. Let us know if you have any dietary restrictions.</p>

--- a/db/migrate/20170319191233_add_custom_question_to_events.rb
+++ b/db/migrate/20170319191233_add_custom_question_to_events.rb
@@ -1,0 +1,5 @@
+class AddCustomQuestionToEvents < ActiveRecord::Migration[5.0]
+  def change
+    add_column :events, :custom_question, :text
+  end
+end

--- a/db/migrate/20170319192836_add_custom_question_answer_to_rsvps.rb
+++ b/db/migrate/20170319192836_add_custom_question_answer_to_rsvps.rb
@@ -1,0 +1,5 @@
+class AddCustomQuestionAnswerToRsvps < ActiveRecord::Migration[5.0]
+  def change
+    add_column :rsvps, :custom_question_answer, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170202035358) do
+ActiveRecord::Schema.define(version: 20170319192836) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -120,6 +120,7 @@ ActiveRecord::Schema.define(version: 20170202035358) do
     t.string   "imported_event_data"
     t.integer  "chapter_id",                                     null: false
     t.boolean  "food_provided",                  default: true,  null: false
+    t.text     "custom_question"
     t.index ["chapter_id"], name: "index_events_on_chapter_id"
   end
 
@@ -266,6 +267,7 @@ ActiveRecord::Schema.define(version: 20170202035358) do
     t.boolean  "checkiner",                           default: false
     t.text     "plus_one_host"
     t.string   "token"
+    t.text     "custom_question_answer"
     t.index ["token"], name: "index_rsvps_on_token", unique: true
     t.index ["user_id", "event_id", "user_type"], name: "index_rsvps_on_user_id_and_event_id_and_event_type", unique: true
   end

--- a/spec/features/events/event_rsvp_request_spec.rb
+++ b/spec/features/events/event_rsvp_request_spec.rb
@@ -205,6 +205,30 @@ describe 'creating or editing an rsvp' do
         end
       end
     end
+
+    describe 'displaying custom question field' do
+      before do
+        @event.update(custom_question: custom_question)
+        visit volunteer_new_event_rsvp_path(@event)
+      end
+
+      context 'when event asks a custom question' do
+        let(:custom_question) { 'What is your t-shirt size?' }
+
+        it 'diplays a field for the user to respond to the custom question' do
+          expect(page).to have_content custom_question
+          expect(page).to have_field('rsvp_custom_question_answer')
+        end
+      end
+
+      context 'when event does not ask a custom question' do
+        let(:custom_question) { '' }
+
+        it 'does not display a field for the user to respond to the custom question' do
+          expect(page).not_to have_field('rsvp_custom_question_answer')
+        end
+      end
+    end
   end
 
   context "for a non-teaching event" do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -598,4 +598,26 @@ describe Event do
       end
     end
   end
+
+  describe '#asks_custom_question?' do
+    context 'when event asks a custom question' do
+      before do
+        allow(subject).to receive(:custom_question) { 'What is your t-shirt size?' }
+      end
+
+      it 'returns true' do
+        expect(subject.asks_custom_question?).to eql true
+      end
+    end
+
+    context 'when event does not ask a custom question' do
+      before do
+        allow(subject).to receive(:custom_question) { '' }
+      end
+
+      it 'returns false' do
+        expect(subject.asks_custom_question?).to eql false
+      end
+    end
+  end
 end


### PR DESCRIPTION
… the RSVP form

Per a discussion with @tjgrathwell on the BridgeTroll Google group, this PR allow event organizers to specify an additional custom question on the RSVP form to collect info such as t-shirt size.