### PR TITLE
Add plain link to confirmation email

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -8,4 +8,9 @@
       <img alt='Confirm your account!' src="http://<%= Rails.configuration.action_mailer.default_url_options[:host] %>/email_images/confirm_account.gif">
     <% end %>
   </p>
+
+  <p>
+    Should the image above not load for any reason, click here:
+      <%= link_to "Sign up to Bridge Troll", confirmation_url(@resource, confirmation_token: @token) %>
+  </p>
 </div>


### PR DESCRIPTION
First of all, thanks for the work on Bridge Troll! :)

When signing up to the Bridge Troll, the image "Confirm your Account" didn't load. This was mildly confusing and I had to get the link out of the email source.

To avoid confusion, this PR adds a plain fallback link that will surely be displayed.