### PR TITLE
Set dynamic HSTS to 1 hour, including subdomains. Addresses #587.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,12 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  before_action do
+    if force_ssl
+      response.set_header("Strict-Transport-Security", "max-age=3600; includeSubDomains")
+    end
+  end
+
   rescue_from(ActionView::MissingTemplate) do |e|
     if request.format != :html
       head(:not_acceptable)


### PR DESCRIPTION
Ahoy! This is a good trial header for HSTS. If that works well, you can aim for a much longer max-age and preloading (see #587).