### PR TITLE
 Bump HSTS max-age to 2 years, and request preloading.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,8 @@ class ApplicationController < ActionController::Base
 
   before_action do
     if force_ssl
-      response.set_header("Strict-Transport-Security", "max-age=3600; includeSubDomains")
+      # See https://hstspreload.org/?domain=bridgetroll.org for information about HSTS preloading.
+      response.set_header("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload")
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,12 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  before_action do
+    if force_ssl
+      response.set_header("Strict-Transport-Security", "max-age=3600; includeSubDomains")
+    end
+  end
+
   rescue_from(ActionView::MissingTemplate) do |e|
     if request.format != :html
       head(:not_acceptable)


### PR DESCRIPTION
This commit should land at least a few days after #587 is confirmed not to cause trouble in production. See issue #587 for additional steps.