### PR TITLE
link to operations guidelines go to rendered rather than source

### DIFF
--- a/app/views/events/_guidelines.html.erb
+++ b/app/views/events/_guidelines.html.erb
@@ -11,7 +11,7 @@
   mission and follow our guidelines below.  You can also work with us 
   more closely and receive additional support and resource from us. If 
   you are interested in learning more about leading an operational chapter, 
-  see our <a href="https://github.com/bridgefoundry/operations">operations guide</a>.
+  see our <a href="https://operations.bridgefoundry.org/">operations guide</a>.
   </p>
 
     <p>All workshops hosted on Bridge Troll must:</p>


### PR DESCRIPTION
Previously, bridgetroll linked to the operations guide source. This updates that to link to the website where the user can more easily read the operations guide.