### PR TITLE
Updating shoulda-matchers gem to rails 5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ group :test do
   gem 'poltergeist', require: false
   gem 'selenium-webdriver', require: false
   gem 'launchy'
-  gem 'shoulda-matchers'
+  gem 'shoulda-matchers', git: 'https://github.com/thoughtbot/shoulda-matchers.git', branch: 'rails-5'
   gem 'faker'
   gem 'capybara-screenshot'
   gem 'database_cleaner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/thoughtbot/shoulda-matchers.git
+  revision: 4b160bd19ecca7f97d7ac22dccd5fde9b0da5a9f
+  branch: rails-5
+  specs:
+    shoulda-matchers (3.1.2)
+      activesupport (>= 4.2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -266,7 +274,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (12.3.1)
+    rake (12.3.2)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
@@ -313,8 +321,6 @@ GEM
       websocket (~> 1.0)
     sentry-raven (2.4.0)
       faraday (>= 0.7.6, < 1.0)
-    shoulda-matchers (3.1.2)
-      activesupport (>= 4.0.0)
     simple_form (3.4.0)
       actionpack (> 4, < 5.1)
       activemodel (> 4, < 5.1)
@@ -405,7 +411,7 @@ DEPENDENCIES
   sass-rails
   selenium-webdriver
   sentry-raven
-  shoulda-matchers
+  shoulda-matchers!
   simple_form
   sqlite3
   uglifier
@@ -415,4 +421,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.2
+   1.16.4


### PR DESCRIPTION
Fixes #603 

```
DEPRECATION WARNING: #tables currently returns both tables and views. This behavior is deprecated and will be changed with Rails 5.1 to only return tables. Use #data_sources instead. (called from block (2 levels) in <top (required)> at /Users/sallen/src/bridge/bridge_troll/spec/models/user_spec.rb:9)
```
