### PR TITLE
Update README directions for installing phantomjs

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -67,7 +67,8 @@ Pro-tip: Confirming Users Locally
 This project has many tests that you should run before submitting a pull request, even if it's just a simple text change. You will need to install PhantomJS to run the tests. On OSX with Homebrew, try
 ```
 brew update
-brew install phantomjs
+brew tap homebrew/cask
+brew cask install phantomjs
 ```
 
 If you are on a Ubuntu-based linux distribution, you can try


### PR DESCRIPTION
Attempted to run phantomjs tests and received this message:

```
% brew install phantomjs
Error: No available formula with the name "phantomjs" 
It was migrated from homebrew/core to homebrew/cask.
You can access it again by running:
  brew tap homebrew/cask
And then you can install it by running:
  brew cask install phantomjs
```