### PR TITLE
Faker::Name.title -> Faker::Job.title

### DIFF
--- a/db/seeds/seed_event.rb
+++ b/db/seeds/seed_event.rb
@@ -22,7 +22,7 @@ module Seeder
       role: Role::VOLUNTEER,
       subject_experience: Faker::Lorem.sentence,
       teaching_experience: Faker::Lorem.sentence,
-      job_details: Faker::Name.title
+      job_details: Faker::Job.title
     }.merge(options)
 
     rsvp = Rsvp.new(rsvp_params)
@@ -36,7 +36,7 @@ module Seeder
     rsvp_params = {
       role: Role::STUDENT,
       operating_system: OperatingSystem.all.sample,
-      job_details: Faker::Name.title
+      job_details: Faker::Job.title
     }.merge(options)
 
     rsvp = Rsvp.new(rsvp_params)


### PR DESCRIPTION
This change stops the test suite from repeatedly printing out the message "NOTE: Faker::Name.title is deprecated; use Faker::Job.title instead. It will be removed on or after 2018-09-01.
Faker::Name.title called from /home/travis/build/railsbridge/bridge_troll/db/seeds/seed_event.rb:25."