### PR TITLE
create staging environment

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -32,6 +32,10 @@ test:
   host: localhost
 <% end %>
 
+staging:
+  url:  <%= ENV["DATABASE_URL"] %>
+  pool: <%= ENV["DB_POOL"] || ENV['MAX_THREADS'] || 5 %>
+
 production:
   url:  <%= ENV["DATABASE_URL"] %>
   pool: <%= ENV["DB_POOL"] || ENV['MAX_THREADS'] || 5 %>

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,0 +1,2 @@
+# Just use the production settings
+require File.expand_path('../production.rb', __FILE__)

--- a/config/initializers/bower_rails.rb
+++ b/config/initializers/bower_rails.rb
@@ -3,7 +3,7 @@ BowerRails.configure do |bower_rails|
   # bower_rails.root_path = Dir.pwd
 
   # Invokes rake bower:install before precompilation. Defaults to false
-  bower_rails.install_before_precompile = Rails.env.production?
+  bower_rails.install_before_precompile = Rails.env.production? || Rails.env.staging?
 
   # Invokes rake bower:resolve before precompilation. Defaults to false
   # bower_rails.resolve_before_precompile = true

--- a/config/initializers/timeout.rb
+++ b/config/initializers/timeout.rb
@@ -1,3 +1,3 @@
-if Rails.env.production?
+if Rails.env.production? || Rails.env.staging?
   Rails.application.config.middleware.insert_before Rack::Runtime, Rack::Timeout, service_timeout: 20
 end

--- a/config/initializers/timeout.rb
+++ b/config/initializers/timeout.rb
@@ -1,3 +1,0 @@
-if Rails.env.production? || Rails.env.staging?
-  Rails.application.config.middleware.insert_before Rack::Runtime, Rack::Timeout, service_timeout: 20
-end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -18,5 +18,9 @@ test:
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
+# keep 'staging' as close to production as possible
+staging:
+  secret_key_base: <%= ENV["SECRET_TOKEN"] %>
+
 production:
   secret_key_base: <%= ENV["SECRET_TOKEN"] %>


### PR DESCRIPTION
I wanted to drop and re-create staging database, and ran into a [Rails warning](https://blog.bigbinary.com/2016/06/07/rails-5-prevents-destructive-action-on-production-db.html) about destroying our "production" database.  

I figured that is a good warning to have, so making a staging environment that mirrors all the production settings.  I used this [blog post](http://nts.strzibny.name/creating-staging-environments-in-rails/) as a guide

