### PR TITLE
Update deprecated devise error messages

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -3,7 +3,7 @@
 <div class="row">
   <div class="col-md-6">
     <%= simple_form_for(resource, :as => resource_name, :url => confirmation_path(resource_name), :html => { :method => :post }) do |f| %>
-      <%= devise_error_messages! %>
+      <%= render "shared/devise_error_messages" if resource.errors.any? %>
 
       <%= f.input :email %>
 

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,7 +1,8 @@
 <h2>Change your password</h2>
 
 <%= form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :put }) do |f| %>
-  <%= devise_error_messages! %>
+  <%= render "shared/devise_error_messages" if resource.errors.any? %>
+
   <%= f.hidden_field :reset_password_token %>
 
   <div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -3,7 +3,7 @@
 <div class="row">
   <div class="col-md-6">
     <%= simple_form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :post }) do |f| %>
-      <%= devise_error_messages! %>
+      <%= render "shared/devise_error_messages" if resource.errors.any? %>
 
       <%= f.input :email %>
 

--- a/app/views/devise/registrations/_form.html.erb
+++ b/app/views/devise/registrations/_form.html.erb
@@ -1,5 +1,5 @@
 <%= simple_form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => {:method => is_registered ? 'put' : 'post'}) do |f| %>
-  <%= devise_error_messages! %>
+  <%= render "shared/devise_error_messages" if resource.errors.any? %>
 
   <% if params[:return_to] %>
     <%= hidden_field_tag :return_to, params[:return_to] %>

--- a/app/views/shared/_devise_error_messages.html.erb
+++ b/app/views/shared/_devise_error_messages.html.erb
@@ -1,0 +1,13 @@
+<div id="error_explanation">
+  <h2>
+    <%= I18n.t("errors.messages.not_saved",
+               count: resource.errors.count,
+               resource: resource.class.model_name.human.downcase)
+     %>
+  </h2>
+  <ul>
+    <% resource.errors.full_messages.each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+  </ul>
+</div>


### PR DESCRIPTION
Addresses https://github.com/railsbridge/bridge_troll/issues/651 deprecated `devise_error_messages!`.