### PR TITLE
Added Learn to Code with Scala to course_populator.rb

### DIFF
--- a/db/seeds/course_populator.rb
+++ b/db/seeds/course_populator.rb
@@ -764,6 +764,38 @@ concepts, like collections and scope.',
             ]
           }
         ]
+      },
+      {
+        id: 20,
+        name: 'Learn to code with Scala',
+        title: 'Learn to code with Scala',
+        description: 'This is a Scala event. At the end of the day, you will have learned to code and to create a couple of fun applications in Scala yourself. ',
+        levels: [
+          {
+            level: 1,
+            color: 'blue',
+            title: 'Beginner',
+            level_description: [
+              'You have never worked with any programming languages before'
+            ]
+          }, {
+            level: 2,
+            color: 'green',
+            title: 'Advanced Beginner',
+            level_description: [
+              'You have worked with other programming languages and know some programming concepts',
+              'You have not worked with Scala before'
+            ]
+          }, {
+            level: 4,
+            color: 'orange',
+            title: 'Novice Scala developer',
+            level_description: [
+              'You have tried Scala before but have no professional experience with it',
+              'Or you have used another functional programming language such as Haskell before'
+            ]
+          }
+        ]
       }
     ]
   end

--- a/db/seeds/course_populator.rb
+++ b/db/seeds/course_populator.rb
@@ -787,7 +787,7 @@ concepts, like collections and scope.',
               'You have not worked with Scala before'
             ]
           }, {
-            level: 4,
+            level: 3,
             color: 'orange',
             title: 'Novice Scala developer',
             level_description: [


### PR DESCRIPTION
NOTE:
This is a *workaround* for https://github.com/railsbridge/bridge_troll/issues/669.

If I understand this codebase correctly, the file I edited adds stuff to a db on startup.
Apparently the new event was added to the db manually. This caused a bug where students cannot sign up.
I hope this change will either overwrite the incorrect version in the database, or add a second one next to it which we can use instead, and which works correctly.

I have not fixed this case for the other course that's not in the course_populator, the Amazon Alexa one, because I have no idea what to put in as a description or course levels.

Someone more familiar with this codebase could look for a more permanent fix, but for now this would help us very much to get our event underway.