### PR TITLE
enables prereqs for hsts registration

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,6 @@ class ApplicationController < ActionController::Base
   after_action :verify_authorized, unless: :devise_controller?
 
   before_action :configure_permitted_parameters, if: :devise_controller?
-  force_ssl if: -> { Rails.env.production? }, unless: :allow_insecure?
 
   before_action do
     if current_user.try(:admin?)
@@ -32,10 +31,6 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up) do |u|
       u.permit(policy(User).permitted_attributes + [region_ids: []])
     end
-  end
-
-  def allow_insecure?
-    false
   end
 
   def user_not_authorized

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -119,8 +119,4 @@ class EventsController < ApplicationController
   def find_event
     @event = Event.find(params[:id])
   end
-
-  def allow_insecure?
-    request.get? && (request.format.json? || request.format.csv?)
-  end
 end

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,4 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment',  __FILE__)
-use Rack::CanonicalHost, ENV['CANONICAL_HOST'] if ENV['CANONICAL_HOST']
 run Bridgetroll::Application

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,13 @@ module Bridgetroll
         resource '/events.json', headers: :any, methods: [:get]
       end
     end
+
+    # taken from https://github.com/tylerhunt/rack-canonical-host/issues/36#issuecomment-330813507
+    # to support HSTS, we want to redirect to SSL before redirecting to www
+
+    config.middleware.insert_after(
+      ActionDispatch::SSL,
+      Rack::CanonicalHost, ENV['CANONICAL_HOST']
+    )
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,15 +29,5 @@ module Bridgetroll
         resource '/events.json', headers: :any, methods: [:get]
       end
     end
-
-    # taken from https://github.com/tylerhunt/rack-canonical-host/issues/36#issuecomment-330813507
-    # to support HSTS, we want to redirect to SSL before redirecting to www
-
-    config.middleware.insert_after(
-      ActionDispatch::SSL,
-      Rack::CanonicalHost,
-      ENV['CANONICAL_HOST'],
-      cache_control: 'max-age=3600'
-    )
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,7 +35,9 @@ module Bridgetroll
 
     config.middleware.insert_after(
       ActionDispatch::SSL,
-      Rack::CanonicalHost, ENV['CANONICAL_HOST']
+      Rack::CanonicalHost,
+      ENV['CANONICAL_HOST'],
+      cache_control: 'max-age=3600'
     )
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,6 +49,7 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
+  config.ssl_options = { hsts: { preload: true } }
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,15 +60,6 @@ Rails.application.configure do
     }
   }
 
-  # taken from https://github.com/tylerhunt/rack-canonical-host/issues/36#issuecomment-330813507
-  # to support HSTS, we want to redirect to SSL before redirecting to www
-  config.middleware.insert_after(
-    ActionDispatch::SSL,
-    Rack::CanonicalHost,
-    ENV['CANONICAL_HOST'],
-    cache_control: 'max-age=3600'
-  )
-
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
   config.log_level = :debug
@@ -121,3 +112,12 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { host: ENV['HOST_URL'] }
 end
+
+# taken from https://github.com/tylerhunt/rack-canonical-host/issues/36#issuecomment-330813507
+# to support HSTS, we want to redirect to SSL before redirecting to www
+Rails.application.middleware.insert_after(
+  ActionDispatch::SSL,
+  Rack::CanonicalHost,
+  ENV['CANONICAL_HOST'],
+  cache_control: 'max-age=3600'
+)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
   config.ssl_options = {
-    hsts: { preload: true },
+    hsts: { preload: true, subdomains: true, expires: 1.year },
     redirect: {
       exclude: -> request {
         request.get? &&

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,8 +48,26 @@ Rails.application.configure do
   # config.action_cable.mount_path = nil
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
-  config.ssl_options = { hsts: { preload: true } }
+  config.force_ssl = true
+  config.ssl_options = {
+    hsts: { preload: true },
+    redirect: {
+      exclude: -> request {
+        request.get? &&
+          (request.format.json? || request.format.csv?) &&
+          Rails.application.routes.recognize_path(request.path)[:controller] == "events"
+      }
+    }
+  }
+
+  # taken from https://github.com/tylerhunt/rack-canonical-host/issues/36#issuecomment-330813507
+  # to support HSTS, we want to redirect to SSL before redirecting to www
+  config.middleware.insert_after(
+    ActionDispatch::SSL,
+    Rack::CanonicalHost,
+    ENV['CANONICAL_HOST'],
+    cache_control: 'max-age=3600'
+  )
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
follows steps outlined in #587 
1. enables hsts headers
2. redirects to ssl BEFORE redirecting to canonical_url / www

another take at #678, #587