### PR TITLE
404 for missing event instead of 500

### DIFF
--- a/app/controllers/events/emails_controller.rb
+++ b/app/controllers/events/emails_controller.rb
@@ -58,7 +58,7 @@ module Events
     end
 
     def find_event
-      @event = Event.find_by(id: params[:event_id])
+      @event = Event.find(params[:event_id])
     end
 
     def present_form_data

--- a/spec/controllers/events/emails_controller_spec.rb
+++ b/spec/controllers/events/emails_controller_spec.rb
@@ -128,5 +128,25 @@ describe Events::EmailsController do
         end
       end
     end
+
+    context 'when there no corresponding event id' do
+      it "returns 404 and doesn't send any email" do
+        old_count = ActionMailer::Base.deliveries.count
+        expect {
+          post(:create,
+            params: {
+              event_id: -1,
+              event_email: mail_params.merge(
+                recipients: [],
+                attendee_group: 'All'
+              )
+            }
+          )
+        }.to raise_error(ActiveRecord::RecordNotFound)
+        # we want to raise this exception so we get a 404 in the frontend
+        # and so 404s don't get classified as 500s in our error tracking software
+        expect(ActionMailer::Base.deliveries.count).to eq old_count
+      end
+    end
   end
 end


### PR DESCRIPTION
created this to resolve https://sentry.io/share/issue/16c7c15692d3438ab83117724f4fb52e/

If we raise RecordNotFound then we'll get 404s in the frontend instead of 500s.