### PR TITLE
add bootsnap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,10 @@ gem 'bower-rails'
 gem 'nearest_time_zone'
 gem 'rack-cors'
 
+# optimize and cache expensive computations for faster boot times. It's
+# `require`d in a specific way in config/boot.rb
+gem 'bootsnap', require: false
+
 group :production do
   gem 'pg'
   gem 'newrelic_rpm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,8 @@ GEM
       rack (>= 0.9.0)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
+    bootsnap (1.4.4)
+      msgpack (~> 1.0)
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
@@ -180,6 +182,7 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
+    msgpack (1.3.1)
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
@@ -377,6 +380,7 @@ DEPENDENCIES
   backbone-on-rails
   better_errors
   binding_of_caller
+  bootsnap
   bootstrap-sass
   bower-rails
   bullet

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+require 'bootsnap/setup'


### PR DESCRIPTION
adds bootsnap, included in rails 5.2+, which improves boot times