### PR TITLE
silences capybara nil-text warning

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -94,6 +94,7 @@ FactoryBot.define do
     sequence(:name) { |n| "Location #{n}" }
     sequence(:address_1) { |n| "#{n} Street" }
     city {"San Francisco"}
+    state { "CA" }
     latitude {37.7955458}
     longitude{-122.3934205}
     region


### PR DESCRIPTION
previously we were testing to find the state on a page, but our state factory had a nil state, so the test was raising an exception