### PR TITLE
Parallel tests

### DIFF
--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,0 +1,2 @@
+--format progress
+--format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ before_script:
   - 'npm install'
   - './config/before-travis.sh'
 script:
-  - 'bundle exec rake rspec_with_retries'
-  - 'bundle exec rake jasmine:ci'
+  - 'bundle exec rake'
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
   bundler: true
   directories:
     - node_modules
+    - tmp
 
 addons:
   chrome: stable

--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ group :development do
 end
 
 group :test, :development do
+  gem 'parallel_tests'
   gem 'byebug'
   gem 'awesome_print'
   gem 'chrome_remote'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,6 +236,9 @@ GEM
       omniauth-oauth (~> 1.1)
       rack
     orm_adapter (0.5.0)
+    parallel (1.17.0)
+    parallel_tests (2.28.0)
+      parallel
     pg (1.1.4)
     phantomjs (2.1.1.0)
     pry (0.12.2)
@@ -418,6 +421,7 @@ DEPENDENCIES
   omniauth-meetup
   omniauth-rails_csrf_protection
   omniauth-twitter
+  parallel_tests
   pg
   pry
   puma

--- a/Rakefile
+++ b/Rakefile
@@ -5,3 +5,7 @@
 require File.expand_path('../config/application', __FILE__)
 
 Bridgetroll::Application.load_tasks
+
+
+Rake::Task["default"].clear
+task :default => [:rspec_with_retries, "jasmine:ci"]

--- a/bin/setup
+++ b/bin/setup
@@ -36,6 +36,9 @@ chdir APP_ROOT do
 
   puts "\n== Preparing database =="
   system! 'bin/rails db:setup'
+  system! 'bin/rake parallel:create'
+  system! 'bin/rake parallel:prepare'
+
 
   puts "\n== Removing old logs and tempfiles =="
   system! 'bin/rails log:clear tmp:clear'

--- a/config/before-travis.sh
+++ b/config/before-travis.sh
@@ -1,2 +1,1 @@
-bundle exec rake db:create:all
-bundle exec rake db:migrate
+bundle exec rake parallel:setup

--- a/config/database.yml
+++ b/config/database.yml
@@ -21,14 +21,14 @@ development:
 # Do not set this db to the same as development or production.
 test:
   adapter: sqlite3
-  database: db/test.sqlite3
+  database: db/test<%= ENV['TEST_ENV_NUMBER'] %>.sqlite3
   pool: 5
   timeout: 5000
 
 <% if ENV['FORCE_POSTGRES'] %>
 test:
   adapter: postgresql
-  database: bridgetroll_test
+  database: bridgetroll_test<%= ENV['TEST_ENV_NUMBER'] %>
   host: localhost
 <% end %>
 

--- a/lib/tasks/support/rspec_rerunner.rb
+++ b/lib/tasks/support/rspec_rerunner.rb
@@ -13,7 +13,7 @@ class RspecRerunner
 
   def run_tests
     Bundler.with_clean_env do
-      succeeded_initially = system("bundle exec rspec spec")
+      succeeded_initially = system("bundle exec rake parallel:spec")
       return if succeeded_initially
     end
 
@@ -25,7 +25,7 @@ class RspecRerunner
 
     RERUN_ATTEMPTS.times do
       Bundler.with_clean_env do
-        succeeded_on_retry = system("bundle exec rspec spec --only-failures")
+        succeeded_on_retry = system("bundle exec rake parallel:spec --only-failures")
         return if succeeded_on_retry
       end
     end


### PR DESCRIPTION
peals about 50 seconds off of travis time and way more off of local CI, system performance allowing time. Simplify `rake`