### PR TITLE
move from hybrid to json cookie serializer

### DIFF
--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -4,4 +4,4 @@
 
 # Specify a serializer for the signed and encrypted cookie jars.
 # Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :hybrid
+Rails.application.config.action_dispatch.cookies_serializer = :json


### PR DESCRIPTION
in #781, we moved from marshall cookie serializer to hybrid serializer.

after 6 months, let's move from hybrid to json serializer