### PR TITLE
Can rsvp with same region

### DIFF
--- a/app/controllers/rsvps_controller.rb
+++ b/app/controllers/rsvps_controller.rb
@@ -112,7 +112,9 @@ class RsvpsController < ApplicationController
 
     if @event.location
       if params[:affiliate_with_region]
-        @rsvp.user.region_ids += [@event.region.id]
+        unless @rsvp.user.region_ids.include? @event.region.id
+          @rsvp.user.region_ids += [@event.region.id]
+        end
       else
         @rsvp.user.region_ids -= [@event.region.id]
       end

--- a/spec/controllers/rsvps_controller_spec.rb
+++ b/spec/controllers/rsvps_controller_spec.rb
@@ -238,6 +238,20 @@ describe RsvpsController do
         post :create, params: { event_id: @event.id, rsvp: @rsvp_params, user: { gender: "human" } }
       end
 
+      it 'can set region affiliation' do
+        expect(@user.regions).to match_array([])
+
+        post :create, params: {event_id: @event.id, rsvp: @rsvp_params, user: {gender: 'human'}, affiliate_with_region: true}
+        expect(@user.reload.regions).to match_array([@event.region])
+      end
+
+      it 'can unset region affiliation' do
+        @user.regions << @event.region
+
+        post :create, params: {event_id: @event.id, rsvp: @rsvp_params, user: {gender: 'human'}}
+        expect(@user.reload.regions).to match_array([])
+      end
+
       it "should generate a token for the RSVP" do
         allow(SecureRandom).to receive(:uuid) { 'thisisatoken' }
         do_request


### PR DESCRIPTION
previously:

if you RSVPed to an event in your region and you had specified to update the region, you would receive a 500.

now it lets you create / update your RSVP