### PR TITLE
Csv can render locationless events

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -65,3 +65,9 @@ Style/HashTransformKeys:
 
 Style/HashTransformValues:
   Enabled: True
+
+Lint/RaiseException:
+  Enabled: True
+
+Lint/StructNewOverride:
+  Enabled: True

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -365,7 +365,7 @@ class Event < ApplicationRecord
   def as_json(options = {})
     options = {
       only: %i[id title student_rsvp_limit imported_event_data],
-      methods: [:location]
+      includes: [:location]
     }.merge(options)
     super(options).merge(
       workshop: !!(allow_student_rsvp || historical?),

--- a/app/services/event_csv_reporter.rb
+++ b/app/services/event_csv_reporter.rb
@@ -54,11 +54,11 @@ class EventCsvReporter
     end
 
     def city
-      event_json[:location][:city]
+      event_json.dig(:location, :city)
     end
 
     def location
-      event_json[:location][:name]
+      event_json.dig(:location, :name)
     end
 
     def title

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -40,7 +40,7 @@ describe EventsController do
     let!(:past_external_event) { create(:external_event, name: 'PastExternalBridge', starts_at: 3.days.ago, ends_at: 2.days.ago) }
 
     before do
-      # unpublished
+      # unpublished, not included in results below
       create(:event, starts_at: 5.days.from_now, ends_at: 6.days.from_now, current_state: :pending_approval)
     end
 
@@ -60,6 +60,16 @@ describe EventsController do
       get :index, params: { type: 'upcoming' }, format: 'json'
       result_titles = JSON.parse(response.body).map { |e| e['title'] }
       expect(result_titles).to eq([future_external_event, future_event].map(&:title))
+    end
+  end
+
+  describe 'GET index (csv)' do
+    let!(:event) { create(:event, :without_location) }
+
+    it 'can render without an event without a location' do
+      get :index, format: :csv
+      result_titles = CSV.parse(response.body, headers: true).map(&:to_h).map { |e| e['title'] }
+      expect(result_titles).to eq [event].map(&:title)
     end
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -60,6 +60,10 @@ FactoryBot.define do
         end
       end
 
+      trait :without_location do
+        location { nil }
+      end
+
       after(:build) do |event, _evaluator|
         event.event_sessions << build(:event_session, event: event, starts_at: event.starts_at, ends_at: event.ends_at)
       end


### PR DESCRIPTION
addresses https://sentry.io/organizations/bridge-troll/issues/1592674011/?referrer=slack

before: http://www.bridgetroll.org/events.csv 500s
now: http://www.bridgetroll.org/events.csv works